### PR TITLE
fix: pin terraform version everywhere

### DIFF
--- a/modules/inbound-load-balancer/versions.tf
+++ b/modules/inbound-load-balancer/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">=0.12.29, <0.14"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/networking-panorama/versions.tf
+++ b/modules/networking-panorama/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">=0.12.29, <0.14"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/networking-vm-series/versions.tf
+++ b/modules/networking-vm-series/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">=0.12.29, <0.14"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/networking/versions.tf
+++ b/modules/networking/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">=0.12.29, <0.14"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/outbound-load-balancer/versions.tf
+++ b/modules/outbound-load-balancer/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">=0.12.29, <0.14"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/panorama/versions.tf
+++ b/modules/panorama/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">=0.12.29, <0.14"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/vm-bootstrap/versions.tf
+++ b/modules/vm-bootstrap/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">=0.12.29, <0.14"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/vm-series/versions.tf
+++ b/modules/vm-series/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">=0.12.29, <0.14"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/vmss/versions.tf
+++ b/modules/vmss/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">=0.12.29, <0.14"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
Do not blindly allow any version of Terraform. Primarily, we want to
avoid a future confusion when a new incompatible version of Terraform
throws a random weird error. Prefer a well-known error about version
mismatch. Fail fast and clean.

Allow versions 0.12.29 and 0.13.6, because they work with the examples.
We will bump to 0.14 one example at a time.