### PR TITLE
feat(panorama): bump to panos 10.0.3

### DIFF
--- a/modules/panorama/README.md
+++ b/modules/panorama/README.md
@@ -41,7 +41,7 @@ module "panorama" {
 | name\_rg | n/a | `string` | `"rg-panorama"` | no |
 | panorama\_size | Virtual Machine size. | `string` | `"Standard_D5_v2"` | no |
 | panorama\_sku | Panorama SKU. | `string` | `"byol"` | no |
-| panorama\_version | PAN-OS Software version. List published images with `az vm image list --publisher paloaltonetworks --offer panorama --all` | `string` | `"9.0.5"` | no |
+| panorama\_version | PAN-OS Software version. List published images with `az vm image list --publisher paloaltonetworks --offer panorama --all` | `string` | `"10.0.3"` | no |
 | password | Panorama Password. | `any` | n/a | yes |
 | sep | Separator used in the names of the generated resources. May be empty. | `string` | `"-"` | no |
 | subnet\_mgmt | Panorama's management subnet ID. | `any` | n/a | yes |

--- a/modules/panorama/variables.tf
+++ b/modules/panorama/variables.tf
@@ -30,7 +30,7 @@ variable "panorama_sku" {
 }
 
 variable "panorama_version" {
-  default     = "9.0.5"
+  default     = "10.0.3"
   description = "PAN-OS Software version. List published images with `az vm image list --publisher paloaltonetworks --offer panorama --all`"
 }
 


### PR DESCRIPTION
Looking at the public images, the 9.0 and 9.1 lag behind as of now,
while the 10.0.x are kept updated nicely with time. To avoid known
bugs, default new deployments to public 10.0.3 image. Customers
who enforce 9.x will be able to specify it manually.