### PR TITLE
docs(vmss): convert to babenko's method

### DIFF
--- a/modules/vmss/README.md
+++ b/modules/vmss/README.md
@@ -1,5 +1,5 @@
-vm-series scale set terraform module
-===========
+Palo Alto Networks VMSS Module for Azure
+========================================
 
 A terraform module for VMSS VM series firewalls in Azure.
 
@@ -8,24 +8,27 @@ Usage
 
 ```hcl
 module "vmss" {
-  source      = "github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules/modules/vmss"
-  location    = "Australia Central"
-  name_prefix = "panostf"
-  password    = "your-password"
-  subnet-mgmt    = azurerm_subnet.subnet-mgmt
-  subnet-private = azurerm_subnet.subnet-private
-  subnet-public  = module.networks.subnet-public
-  bootstrap-storage-account     = module.panorama.bootstrap-storage-account
-  bootstrap-share-name  = "inboundsharename"
-  vhd-container           = "vhd-storage-container-name"
-  lb_backend_pool_id = "private-backend-pool-id"
+  source = "github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules/modules/vmss"
+
+  location                  = "Australia Central"
+  name_prefix               = "panostf"
+  password                  = "your-password"
+  subnet-mgmt               = azurerm_subnet.subnet-mgmt
+  subnet-private            = azurerm_subnet.subnet-private
+  subnet-public             = module.networks.subnet-public
+  bootstrap-storage-account = module.panorama.bootstrap-storage-account
+  bootstrap-share-name      = "inboundsharename"
+  vhd-container             = "vhd-storage-container-name"
+  lb_backend_pool_id        = "private-backend-pool-id"
 }
 ```
 
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
+| terraform | >=0.12.29, <0.14 |
 | azurerm | >=2.26.0 |
 
 ## Providers
@@ -71,4 +74,6 @@ module "vmss" {
 | Name | Description |
 |------|-------------|
 | inbound-scale-set-name | Name of inbound scale set |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/modules/vmss/main.tf
+++ b/modules/vmss/main.tf
@@ -1,31 +1,3 @@
-/*
-* vm-series scale set terraform module
-* ===========
-* 
-* A terraform module for VMSS VM series firewalls in Azure.
-* 
-* Usage
-* -----
-* 
-* ```hcl
-* module "vmss" {
-*   source = "github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules/modules/vmss"
-*
-*   location                  = "Australia Central"
-*   name_prefix               = "panostf"
-*   password                  = "your-password"
-*   subnet-mgmt               = azurerm_subnet.subnet-mgmt
-*   subnet-private            = azurerm_subnet.subnet-private
-*   subnet-public             = module.networks.subnet-public
-*   bootstrap-storage-account = module.panorama.bootstrap-storage-account
-*   bootstrap-share-name      = "inboundsharename"
-*   vhd-container             = "vhd-storage-container-name"
-*   lb_backend_pool_id        = "private-backend-pool-id"
-* }
-* ```
-*/
-
-## All the config required for a single VM series Firewall in Azure
 # Base resource group
 resource "azurerm_resource_group" "vmss" {
   location = var.location


### PR DESCRIPTION
## Description

Setup automatic generation of README per:
https://github.com/antonbabenko/pre-commit-terraform#notes-about-terraform_docs-hooks

We can now avoid repeating ourselves: remove the large main.tf comment.

Follow-up to the process started by Jakub [https://github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules/pull/14](PR14)

## Action required from contributors
Every contributor now needs to install and run pre-commit when changing these descriptions.
If you don't trust git hooks, a decent replacement is: pre-commit run -a
This command refreshes all the README.md files that contain that "magic comment" and do not touch git things at all.

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
