### PR TITLE
feat(vm-series): add enable_plan

### DIFF
--- a/modules/vm-series/README.md
+++ b/modules/vm-series/README.md
@@ -46,35 +46,31 @@ ___NOTE:___ The module only supports Azure regions that have more than one fault
 |------|-------------|------|---------|:--------:|
 | bootstrap-share-name | Azure File share for bootstrap config | `any` | n/a | yes |
 | bootstrap-storage-account | Storage account setup for bootstrapping | `any` | n/a | yes |
+| custom\_image\_id | Absolute ID of your own Custom Image to be used for creating new VM-Series. If set, the `username`, `password`, `vm_series_version`, `vm_series_publisher`, `vm_series_offer`, `vm_series_sku` inputs are all ignored (these are used only for published images, not custom ones). The Custom Image is expected to contain PAN-OS software. | `string` | `null` | no |
+| enable\_plan | Enable usage of the Offer/Plan on Azure Marketplace. Even plan sku "byol", which means "bring your own license", still requires accepting on the Marketplace (as of 2021). Can be set to `false` when using a custom image. | `bool` | `true` | no |
+| instances | Map of instances to create. Keys are instance identifiers, values are objects with specific attributes. | `any` | n/a | yes |
 | lb\_backend\_pool\_id | ID Of inbound load balancer backend pool to associate with the VM series firewall | `any` | n/a | yes |
 | location | Region to install vm-series and dependencies. | `any` | n/a | yes |
-| name\_az | n/a | `string` | `"ib-vm-az"` | no |
-| name\_fw\_ip\_mgmt | n/a | `string` | `"ib-fw-ip-mgmt"` | no |
-| name\_fw\_ip\_private | n/a | `string` | `"ib-fw-ip-private"` | no |
-| name\_fw\_ip\_public | n/a | `string` | `"ib-fw-ip-public"` | no |
-| name\_inbound\_fw | n/a | `string` | `"ib-fw"` | no |
-| name\_nic\_fw\_mgmt | n/a | `string` | `"ib-nic-fw-mgmt"` | no |
-| name\_nic\_fw\_private | n/a | `string` | `"ib-nic-fw-private"` | no |
-| name\_nic\_fw\_public | n/a | `string` | `"ib-nic-fw-public"` | no |
-| name\_pip\_fw\_mgmt | n/a | `string` | `"ib-fw-pip"` | no |
-| name\_pip\_fw\_public | n/a | `string` | `"ib-pip-fw-public"` | no |
+| managed\_disk\_type | Type of Managed Disk which should be created. Possible values are `Standard_LRS`, `StandardSSD_LRS` or `Premium_LRS`. The `Premium_LRS` works only for selected `vm_size` values, details in Azure docs. | `string` | `"StandardSSD_LRS"` | no |
+| name\_avset | Name of the Availability Set to be created. Can be `null`, in which case a default name is auto-generated. | `string` | `null` | no |
 | name\_prefix | Prefix to add to all the object names here | `any` | n/a | yes |
 | password | VM-Series Password | `any` | n/a | yes |
 | resource\_group | The resource group for VM series. | `any` | n/a | yes |
-| sep | Seperator | `string` | `"-"` | no |
 | subnet-mgmt | Management subnet. | `any` | n/a | yes |
 | subnet-private | internal/private subnet resource | `any` | n/a | yes |
 | subnet-public | External/public subnet resource | `any` | n/a | yes |
+| tags | A map of tags to be associated with the resources created. | `map` | `{}` | no |
 | username | VM-Series Username | `string` | `"panadmin"` | no |
-| vm\_count | Count of VM-series of each type (inbound/outbound) to deploy. Min 2 required for production. | `number` | `2` | no |
+| vm\_series\_offer | The Azure Offer identifier corresponding to a published image. For `vm_series_version` 9.1.1 or above, use "vmseries-flex"; for 9.1.0 or below use "vmseries1". | `string` | `"vmseries-flex"` | no |
+| vm\_series\_publisher | The Azure Publisher identifier for a image which should be deployed. | `string` | `"paloaltonetworks"` | no |
 | vm\_series\_sku | VM-series SKU - list available with az vm image list --publisher paloaltonetworks --all | `string` | `"bundle2"` | no |
 | vm\_series\_version | VM-series Software version | `string` | `"9.0.4"` | no |
-| vmseries\_size | Default size for VM series | `string` | `"Standard_D5_v2"` | no |
+| vm\_size | Azure VM size (type) to be created. Consult the *VM-Series Deployment Guide* as only a few selected sizes are supported. | `string` | `"Standard_D3_v2"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| inbound-fw-pips | Inbound firewall Public IPs |
+| ip\_addresses | Inbound firewall Public IPs |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/vm-series/main.tf
+++ b/modules/vm-series/main.tf
@@ -105,10 +105,14 @@ resource "azurerm_virtual_machine" "this" {
     version   = var.custom_image_id == null ? var.vm_series_version : null
   }
 
-  plan {
-    name      = var.vm_series_sku
-    publisher = var.vm_series_publisher
-    product   = var.vm_series_offer
+  dynamic "plan" {
+    for_each = var.enable_plan ? ["one"] : []
+
+    content {
+      name      = var.vm_series_sku
+      publisher = var.vm_series_publisher
+      product   = var.vm_series_offer
+    }
   }
 
   storage_os_disk {

--- a/modules/vm-series/variables.tf
+++ b/modules/vm-series/variables.tf
@@ -61,6 +61,12 @@ variable "custom_image_id" {
   type        = string
 }
 
+variable "enable_plan" {
+  description = "Enable usage of the Offer/Plan on Azure Marketplace. Even plan sku \"byol\", which means \"bring your own license\", still requires accepting on the Marketplace (as of 2021). Can be set to `false` when using a custom image."
+  default     = true
+  type        = bool
+}
+
 variable "vm_series_publisher" {
   description = "The Azure Publisher identifier for a image which should be deployed."
   default     = "paloaltonetworks"


### PR DESCRIPTION
Not all images work with a `plan{}` clause, so make it conditional. It
seems necessary for bundle1/2. For some users it may prevent usage of
a custom image, if they are unable to officially accept what seemingly
is just a dummy "purchase" on Azure Marketplace.

For all users it prevents deploying a linux for temporary troubleshooting.
