### PR TITLE
fix(bootstrap): storaccount invalid chars

### DIFF
--- a/modules/vm-bootstrap/main.tf
+++ b/modules/vm-bootstrap/main.tf
@@ -8,7 +8,7 @@ resource "azurerm_resource_group" "this" {
 resource "azurerm_storage_account" "this" {
   count = var.create_storage_account ? 1 : 0
 
-  name                     = lower(coalesce(var.storage_account_name, replace("${var.name_prefix}bootstrap", "/[_-]+/", "")))
+  name                     = substr(lower(coalesce(var.storage_account_name, replace("${var.name_prefix}bootstrap", "/[_-]+/", ""))), 0, 23)
   account_replication_type = "LRS"
   account_tier             = "Standard"
   location                 = azurerm_resource_group.this[0].location


### PR DESCRIPTION
Remove invalid chars. Azure error says the name:
can only consist of lowercase letters and numbers, and must be between 3
and 24 characters long
