### PR TITLE
feat(vm-series): add Application Insights metrics

### DIFF
--- a/modules/vm-series/main.tf
+++ b/modules/vm-series/main.tf
@@ -136,3 +136,13 @@ resource "azurerm_virtual_machine" "this" {
     identity_ids = var.identity_ids
   }
 }
+
+resource "azurerm_application_insights" "this" {
+  count = var.metrics_retention_in_days != 0 ? 1 : 0
+
+  name                = var.name_prefix
+  location            = var.location
+  resource_group_name = var.resource_group_name # same RG, so no RBAC modification is needed
+  application_type    = "other"
+  retention_in_days   = var.metrics_retention_in_days
+}

--- a/modules/vm-series/outputs.tf
+++ b/modules/vm-series/outputs.tf
@@ -8,3 +8,8 @@ output "principal_id" {
   description = "A map of Azure Service Principals for each of the created VM-Series. Map's key is the same as virtual machine key, the value is an oid of a Service Principal. Usable only if `identity_type` contains SystemAssigned."
   value       = { for k, v in var.instances : k => azurerm_virtual_machine.this[k].identity[0].principal_id if var.identity_type != null && var.identity_type != "" }
 }
+
+output "metrics_instrumentation_key" {
+  description = "The Instrumentation Key of the created instance of Azure Application Insights. The instance is unused by default, but is ready to receive custom PAN-OS metrics from the firewalls. To use it, paste this Instrumentation Key into PAN-OS -> Device -> VM-Series -> Azure."
+  value       = try(azurerm_application_insights.this[0].instrumentation_key, null)
+}

--- a/modules/vm-series/variables.tf
+++ b/modules/vm-series/variables.tf
@@ -130,3 +130,9 @@ variable "identity_ids" {
   default     = null
   type        = list(string)
 }
+
+variable "metrics_retention_in_days" {
+  description = "Specifies the retention period in days. Possible values are 0, 30, 60, 90, 120, 180, 270, 365, 550 or 730. Defaults to 90. A special value 0 disables creation of Application Insights altogether."
+  default     = null
+  type        = number
+}


### PR DESCRIPTION
Verified that the defaults here do not currently cost anything and do
not require extra permissions. Users are billed only when they actually
manually paste the metrics_instrumentation_key by GB of metrics sent.

An opinionated setup is thus to furnish a single Application Insights
for every module instantiation.

Seemingly, no RBAC changes are required for this to work, it doesn't
matter if firewall runs on a `SystemAssigned` or a `UserAssigned` or even
`null` Identity.
