### PR TITLE
(vnet): Add conditional expressions for resources association

### DIFF
--- a/modules/vnet/main.tf
+++ b/modules/vnet/main.tf
@@ -92,14 +92,14 @@ resource "azurerm_route" "this" {
 }
 
 resource "azurerm_subnet_network_security_group_association" "this" {
-  for_each = var.subnets
+  for_each = { for k, v in var.subnets : k => v if lookup(v, "network_security_group", "") != "" }
 
   subnet_id                 = azurerm_subnet.this[each.key].id
   network_security_group_id = azurerm_network_security_group.this[each.value.network_security_group].id
 }
 
 resource "azurerm_subnet_route_table_association" "this" {
-  for_each = var.subnets
+  for_each = { for k, v in var.subnets : k => v if lookup(v, "route_table", "") != "" }
 
   subnet_id      = azurerm_subnet.this[each.key].id
   route_table_id = azurerm_route_table.this[each.value.route_table].id


### PR DESCRIPTION
## Description

Currently, when defining a subnet in `var.subnets`, the `network_security_group` and `route_table` arguments have to be defined for every subnet map, otherwise the "azurerm_subnet_route_table_association" and "azurerm_subnet_network_security_group_association" resource creation fail and terraform returns an error. To fix this issue, I want to add a conditional expression for both of the resources to skip the subnet association if a given argument in a subnet map hasn't been defined.

## Motivation and Context

Allow subnets to be created without a network security group or route table association.

## How Has This Been Tested?

This has been tested by running the example `vnet` module deployment, using the subnets definition shown below:

```hcl
subnets = {
  "management" = {
    address_prefixes       = ["10.112.255.0/24"]
    route_table            = "route_table_1"
  },
  "private" = {
    address_prefixes       = ["10.112.0.0/24"]
    network_security_group = "network_security_group_2"
  },
  "public" = {
    address_prefixes       = ["10.112.129.0/24"]
  },
}
```
The test confirmed the expected result by associating the "management" subnet with a route table, the "private" subnet with a network security group and a "public" subnet with no associations.

## Types of changes

- Fix
