### PR TITLE
TERRAM-40: Add README.md to vmseries_scalset example

### DIFF
--- a/examples/vmseries_scaleset/README.md
+++ b/examples/vmseries_scaleset/README.md
@@ -6,11 +6,10 @@ This folder shows an example of Terraform code that helps to deploy an auto-scal
 
 ## Quick Start
 
-1. Install [Terraform](https://www.terraform.io/). The Terraform version required to run this module can be checked [here](./versions.tf).
-1. `git clone` this repository to your computer, navigate into:
+* Install [Terraform](https://www.terraform.io/). The Terraform version required to run this module can be checked [here](./versions.tf).
+* `git clone` this repository to your computer, navigate into:
 
-    >/terraform-azurerm-vmseries-modules/examples/vnet
+    >/terraform-azurerm-vmseries-modules/examples/vmseries_scalset
 
-1. Run `terraform init` to initialize the working directory.
-1. Run `terraform plan` and verify the execution plan.
-1. Run `terraform apply` to apply the changes required to reach the desired state of the configuration specified for this example.
+* Run `terraform init` to initialize the working directory.
+* Run `terraform apply` to apply the changes required to reach the desired state of the configuration specified for this example.


### PR DESCRIPTION
## Description

Add a README.md to the vmseries_scalset example.

## Motivation and Context

Unify the examples module structure in compliance to our terraform-best-practices documentation.

## How Has This Been Tested?

Documentation updates, no need to test.