### PR TITLE
TERRAM-82: Clean init-cfg.sample files

### DIFF
--- a/examples/bootstrap/files/init-cfg.sample.txt
+++ b/examples/bootstrap/files/init-cfg.sample.txt
@@ -1,8 +1,8 @@
 type=dhcp-client
-vm-auth-key=xxxxxyyyyyzzzzz
-panorama-server=aaa.bbb.ccc.ddd
-tplname=some-stack
-dgname=some_dg
+vm-auth-key=
+panorama-server=
+tplname=
+dgname=
 dhcp-send-hostname=yes
 dhcp-send-client-id=yes
 dhcp-accept-server-hostname=yes

--- a/examples/transit_vnet_common/files/init-cfg.sample.txt
+++ b/examples/transit_vnet_common/files/init-cfg.sample.txt
@@ -1,9 +1,8 @@
 type=dhcp-client
-vm-auth-key=123456789012345
-panorama-server=10.1.2.3
-panorama-server-2=10.1.2.4
-tplname=my-stack
-dgname=my-device-group
+vm-auth-key=
+panorama-server=
+tplname=
+dgname=
 dhcp-send-hostname=yes
 dhcp-send-client-id=yes
 dhcp-accept-server-hostname=yes

--- a/examples/vmseries_scaleset/files/init-cfg.sample.txt
+++ b/examples/vmseries_scaleset/files/init-cfg.sample.txt
@@ -1,8 +1,8 @@
 type=dhcp-client
-vm-auth-key=xxxxxyyyyyzzzzz
-panorama-server=aaa.bbb.ccc.ddd
-tplname=some-stack
-dgname=some_dg
+vm-auth-key=
+panorama-server=
+tplname=
+dgname=
 dhcp-send-hostname=yes
 dhcp-send-client-id=yes
 dhcp-accept-server-hostname=yes

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -5,6 +5,8 @@ to [bootstrap a VM-Series firewalls in Azure](https://docs.paloaltonetworks.com/
 
 The module does *not* configure the bootstrap images, licenses, or configurations.
 
+The following sample basic configuration [init-cfg.txt](https://docs.paloaltonetworks.com/vm-series/9-1/vm-series-deployment/bootstrap-the-vm-series-firewall/create-the-init-cfgtxt-file/sample-init-cfgtxt-file.html) files shows all the parameters that are supported in the file.
+
 ## Usage
 
 See the examples/vm-series directory.


### PR DESCRIPTION
## Description

The init-cfg refactoring.

## Motivation and Context

The data in init-cfg.sample.txt doesn't reflected any use case in our example.tfvars. It can be misleading.

## How Has This Been Tested?

Due to cosmetic changes it has not been tested for each of modules separately.  VM-series is not effected if no data is provided.
