### PR TITLE
fix(examples/panorama): input for priv ip

### DIFF
--- a/examples/panorama/README.md
+++ b/examples/panorama/README.md
@@ -54,14 +54,14 @@ $ terraform apply
 | <a name="input_avzone"></a> [avzone](#input\_avzone) | n/a | `string` | `null` | no |
 | <a name="input_custom_image_id"></a> [custom\_image\_id](#input\_custom\_image\_id) | n/a | `string` | `null` | no |
 | <a name="input_firewall_mgmt_prefixes"></a> [firewall\_mgmt\_prefixes](#input\_firewall\_mgmt\_prefixes) | n/a | `list` | <pre>[<br>  "10.0.0.0/24"<br>]</pre> | no |
-| <a name="input_location"></a> [location](#input\_location) | Region to deploy Panorama into. If not provided location will be taken from Resource Group. | `string` | `""` | no |
+| <a name="input_location"></a> [location](#input\_location) | Region to deploy Panorama into. | `string` | `""` | no |
 | <a name="input_management_ips"></a> [management\_ips](#input\_management\_ips) | A map where the keys are the IP addresses or ranges that are permitted to access the out-of-band management interfaces belonging to firewalls and Panorama devices. The map's values are priorities, integers in the range 102-60000 inclusive. All priorities should be unique. | `map(number)` | n/a | yes |
 | <a name="input_panorama_name"></a> [panorama\_name](#input\_panorama\_name) | n/a | `string` | `"panorama"` | no |
 | <a name="input_panorama_private_ip_address"></a> [panorama\_private\_ip\_address](#input\_panorama\_private\_ip\_address) | Optional static private IP address of Panorama, for example 192.168.11.22. If empty, Panorama uses dynamic assignment. | `string` | `null` | no |
 | <a name="input_panorama_size"></a> [panorama\_size](#input\_panorama\_size) | n/a | `string` | `"Standard_D5_v2"` | no |
 | <a name="input_panorama_sku"></a> [panorama\_sku](#input\_panorama\_sku) | n/a | `string` | `"byol"` | no |
 | <a name="input_panorama_version"></a> [panorama\_version](#input\_panorama\_version) | n/a | `string` | `"10.0.3"` | no |
-| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the Resource Group to use. | `string` | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the Resource Group to create. | `string` | n/a | yes |
 | <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | n/a | `string` | `"nsg-panorama"` | no |
 | <a name="input_storage_account_name"></a> [storage\_account\_name](#input\_storage\_account\_name) | Default name of the storage account to create.<br>The name you choose must be unique across Azure. The name also must be between 3 and 24 characters in length, and may include only numbers and lowercase letters. | `string` | `"pantfstorage"` | no |
 | <a name="input_subnet_names"></a> [subnet\_names](#input\_subnet\_names) | n/a | `list` | <pre>[<br>  "subnet1"<br>]</pre> | no |
@@ -76,4 +76,5 @@ $ terraform apply
 |------|-------------|
 | <a name="output_panorama_admin_password"></a> [panorama\_admin\_password](#output\_panorama\_admin\_password) | Panorama administrator's initial password. |
 | <a name="output_panorama_url"></a> [panorama\_url](#output\_panorama\_url) | Panorama instance URL. |
+| <a name="output_username"></a> [username](#output\_username) | Panorama administrator's initial username. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/panorama/README.md
+++ b/examples/panorama/README.md
@@ -57,6 +57,7 @@ $ terraform apply
 | <a name="input_location"></a> [location](#input\_location) | Region to deploy Panorama into. If not provided location will be taken from Resource Group. | `string` | `""` | no |
 | <a name="input_management_ips"></a> [management\_ips](#input\_management\_ips) | A map where the keys are the IP addresses or ranges that are permitted to access the out-of-band management interfaces belonging to firewalls and Panorama devices. The map's values are priorities, integers in the range 102-60000 inclusive. All priorities should be unique. | `map(number)` | n/a | yes |
 | <a name="input_panorama_name"></a> [panorama\_name](#input\_panorama\_name) | n/a | `string` | `"panorama"` | no |
+| <a name="input_panorama_private_ip_address"></a> [panorama\_private\_ip\_address](#input\_panorama\_private\_ip\_address) | Optional static private IP address of Panorama, for example 192.168.11.22. If empty, Panorama uses dynamic assignment. | `string` | `null` | no |
 | <a name="input_panorama_size"></a> [panorama\_size](#input\_panorama\_size) | n/a | `string` | `"Standard_D5_v2"` | no |
 | <a name="input_panorama_sku"></a> [panorama\_sku](#input\_panorama\_sku) | n/a | `string` | `"byol"` | no |
 | <a name="input_panorama_version"></a> [panorama\_version](#input\_panorama\_version) | n/a | `string` | `"10.0.3"` | no |

--- a/examples/panorama/main.tf
+++ b/examples/panorama/main.tf
@@ -85,9 +85,9 @@ module "panorama" {
     {
       name               = "mgmt"
       subnet_id          = module.vnet.vnet_subnets[0]
-      private_ip_address = "10.0.0.6"  // Optional: If not set, use dynamic allocation
-      public_ip          = "true"      // (optional|bool, default: "false")
-      public_ip_name     = "public_ip" // (optional|string, default: "")
+      private_ip_address = var.panorama_private_ip_address // Optional: If not set, use dynamic allocation
+      public_ip          = true                            // (optional|bool,   default: false)
+      public_ip_name     = "public_ip"                     // (optional|string, default: "")
     }
   ]
 

--- a/examples/panorama/outputs.tf
+++ b/examples/panorama/outputs.tf
@@ -7,3 +7,8 @@ output "panorama_admin_password" {
   description = "Panorama administrator's initial password."
   value       = random_password.this.result
 }
+
+output "username" {
+  description = "Panorama administrator's initial username."
+  value       = var.username
+}

--- a/examples/panorama/variables.tf
+++ b/examples/panorama/variables.tf
@@ -1,11 +1,11 @@
 variable "location" {
-  description = "Region to deploy Panorama into. If not provided location will be taken from Resource Group."
+  description = "Region to deploy Panorama into."
   default     = ""
   type        = string
 }
 
 variable "resource_group_name" {
-  description = "Name of the Resource Group to use."
+  description = "Name of the Resource Group to create."
   type        = string
 }
 

--- a/examples/panorama/variables.tf
+++ b/examples/panorama/variables.tf
@@ -64,6 +64,12 @@ variable "subnet_prefixes" {
   default = ["10.0.0.0/24"]
 }
 
+variable "panorama_private_ip_address" {
+  description = "Optional static private IP address of Panorama, for example 192.168.11.22. If empty, Panorama uses dynamic assignment."
+  type        = string
+  default     = null
+}
+
 variable "vnet_name" {
   type = string
 }

--- a/modules/panorama/main.tf
+++ b/modules/panorama/main.tf
@@ -22,7 +22,7 @@ resource "azurerm_network_interface" "this" {
     subnet_id                     = var.interface[0].subnet_id
     private_ip_address_allocation = lookup(var.interface[0], "private_ip_address", null) != null ? "static" : "dynamic"
     private_ip_address            = lookup(var.interface[0], "private_ip_address", null) != null ? var.interface[0].private_ip_address : null
-    public_ip_address_id          = lookup(var.interface[0], "public_ip", "false") != "false" ? try(azurerm_public_ip.this[0].id) : null
+    public_ip_address_id          = lookup(var.interface[0], "public_ip", false) ? azurerm_public_ip.this[0].id : null
   }
 
   tags = var.tags

--- a/modules/panorama/main.tf
+++ b/modules/panorama/main.tf
@@ -1,6 +1,6 @@
 # Create a public IP for management
 resource "azurerm_public_ip" "this" {
-  count = var.interface[0].public_ip == "true" ? 1 : 0
+  count = var.interface[0].public_ip == true ? 1 : 0
 
   name                = var.interface[0].public_ip_name
   location            = var.location
@@ -15,7 +15,7 @@ resource "azurerm_network_interface" "this" {
   name                 = var.interface[0].name
   location             = var.location
   resource_group_name  = var.resource_group_name
-  enable_ip_forwarding = lookup(var.interface[0], "enable_ip_forwarding", "false")
+  enable_ip_forwarding = lookup(var.interface[0], "enable_ip_forwarding", false)
 
   ip_configuration {
     name                          = var.interface[0].name

--- a/modules/panorama/variables.tf
+++ b/modules/panorama/variables.tf
@@ -68,9 +68,9 @@ variable "interface" {
       name                 = "mgmt"
       subnet_id            = ""
       private_ip_address   = ""
-      public_ip            = "true"
+      public_ip            = true
       public_ip_name       = ""
-      enable_ip_forwarding = "false"
+      enable_ip_forwarding = false
     }
   ]
   ```


### PR DESCRIPTION
## Description

Subnet cidr is an input, but can only be modified if priv ip is not
hardcoded. Making it an input as well.

Minor fixes for the module, non-breaking.