### PR TITLE
fix(module/vmseries): Destroy issue with vmseries module and loadbalancer backend

### DIFF
--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -111,6 +111,8 @@ resource "azurerm_virtual_machine" "this" {
     type         = var.identity_type
     identity_ids = var.identity_ids
   }
+
+  depends_on = [azurerm_network_interface_backend_address_pool_association.this]
 }
 
 resource "azurerm_application_insights" "this" {


### PR DESCRIPTION
## Description

Due to issue with not proper clean-up resources the terraform raised error.

```
Error: Error waiting for removal of Backend Address Pool Association for NIC "fw00-private" (Resource Group "luca2RG"): Code="OperationNotAllowed" Message="Operation 'startTenantUpdate' is not allowed on VM 'pantffw00' since the VM is marked for deletion. You can only retry the Delete operation (or wait for an ongoing one to complete)." Details=[]
```

## Motivation and Context

It could effect automation lifecycle used by CI/CD tools.

## The alternatives
The quick workaround:
```
terraform destroy -parallelism=1
```

## How Has This Been Tested?

The tests was performed on default examples values from transit-vnet-common.
