### PR TITLE
fix(examples/panorama): change Public IP to SKU "Standard"

### DIFF
--- a/modules/panorama/main.tf
+++ b/modules/panorama/main.tf
@@ -6,6 +6,7 @@ resource "azurerm_public_ip" "this" {
   location            = var.location
   resource_group_name = var.resource_group_name
   allocation_method   = "Static"
+  sku                 = "Standard"
 
   tags = var.tags
 }

--- a/modules/panorama/versions.tf
+++ b/modules/panorama/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.29, <=0.15"
+  required_version = ">=0.12.29, <0.14"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/panorama/versions.tf
+++ b/modules/panorama/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.29, <0.14"
+  required_version = ">=0.12.29, <=0.15"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
## Description

- Changed Version Constraint to Include TF 0.15
- Added SKU = "Standard" to Public IP in Panorama Module.

## Motivation and Context

I use TF 0.15 and I was receiving this error when deploying Panorama within an Availabilty Zone:
```
Error: updating Network Interface: (Name "mgmt" / Resource Group "panorama"): network.InterfacesClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="ComputeResourceZoneConstraintDoesNotMatchPublicIPAddressZoneConstraint" Message="Compute resource /subscriptions/137***016/resourceGroups/panorama/providers/Microsoft.Compute/virtualMachines/pano-deploy has a zone constraint 1 but the PublicIPAddress /subscriptions/137***016/resourceGroups/panorama/providers/Microsoft.Network/publicIPAddresses/pano_pip used by the compute resource via NetworkInterface or LoadBalancer has a different zone constraint Regional." Details=[]
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Performed a test deployment of Panorama and this fixed the error.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly. - No changes needed
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
