### PR TITLE
feat: allow terraform 0.14.x on every module

### DIFF
--- a/examples/bootstrap/README.md
+++ b/examples/bootstrap/README.md
@@ -22,7 +22,7 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.14 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.15 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>2.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~>3.0 |
 

--- a/examples/bootstrap/versions.tf
+++ b/examples/bootstrap/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.29, <0.14"
+  required_version = ">=0.12.29, <0.15"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/panorama/README.md
+++ b/examples/panorama/README.md
@@ -18,7 +18,7 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.13, <0.14 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.13, <0.15 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>2.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~>3.0 |
 

--- a/examples/panorama/versions.tf
+++ b/examples/panorama/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.13, <0.14"
+  required_version = ">=0.13, <0.15"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/transit_vnet_common/README.md
+++ b/examples/transit_vnet_common/README.md
@@ -16,7 +16,7 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.13, <0.14 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.13, <0.15 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | =2.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~>3.0 |
 

--- a/examples/transit_vnet_common/versions.tf
+++ b/examples/transit_vnet_common/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.13, <0.14"
+  required_version = ">=0.13, <0.15"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/vmseries_scaleset/README.md
+++ b/examples/vmseries_scaleset/README.md
@@ -18,7 +18,7 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.14 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.15 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>2.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~>3.0 |
 

--- a/examples/vmseries_scaleset/versions.tf
+++ b/examples/vmseries_scaleset/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.29, <0.14"
+  required_version = ">=0.12.29, <0.15"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/vnet/README.md
+++ b/examples/vnet/README.md
@@ -18,7 +18,7 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.14 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.15 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=2.26.0 |
 
 ## Providers

--- a/examples/vnet/versions.tf
+++ b/examples/vnet/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">=0.12.29, <0.14"
+  required_version = ">=0.12.29, <0.15"
 }

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -14,7 +14,7 @@ See the examples/vm-series directory.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.14 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.15 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>2.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~>3.0 |
 

--- a/modules/bootstrap/versions.tf
+++ b/modules/bootstrap/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.29, <0.14"
+  required_version = ">=0.12.29, <0.15"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/loadbalancer/README.md
+++ b/modules/loadbalancer/README.md
@@ -61,7 +61,7 @@ module "outbound_lb" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.14 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.15 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>2.42 |
 
 ## Providers

--- a/modules/loadbalancer/versions.tf
+++ b/modules/loadbalancer/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.29, <0.14"
+  required_version = ">=0.12.29, <0.15"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/panorama/README.md
+++ b/modules/panorama/README.md
@@ -38,7 +38,7 @@ module "panorama" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.14 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.15 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>2.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~>3.0 |
 

--- a/modules/panorama/versions.tf
+++ b/modules/panorama/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.29, <0.14"
+  required_version = ">=0.12.29, <0.15"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -57,7 +57,7 @@ If your Region doesn't, use an alternative mechanism of Availability Set, which 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.14 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.15 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>2.26 |
 
 ## Providers

--- a/modules/vmseries/versions.tf
+++ b/modules/vmseries/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.29, <0.14"
+  required_version = ">=0.12.29, <0.15"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/vmss/README.md
+++ b/modules/vmss/README.md
@@ -26,7 +26,7 @@ module "vmss" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.14 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.15 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=2.26.0 |
 
 ## Providers

--- a/modules/vmss/versions.tf
+++ b/modules/vmss/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.29, <0.14"
+  required_version = ">=0.12.29, <0.15"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/vnet/README.md
+++ b/modules/vnet/README.md
@@ -31,7 +31,7 @@ module "vnet" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.14 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.15 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>2.26 |
 
 ## Providers

--- a/modules/vnet/versions.tf
+++ b/modules/vnet/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.29, <0.14"
+  required_version = ">=0.12.29, <0.15"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
## Description

Allow Terraform version 0.14.x on every module and every example.
Previously the latest compatible version was 0.13.x.

## How Has This Been Tested?

All examples have been applied and then destroyed.
