### PR TITLE
feat!: Mark selected outputs as sensitive, allow tf-0.15, require azurerm-2.46+

### DIFF
--- a/examples/bootstrap/README.md
+++ b/examples/bootstrap/README.md
@@ -12,9 +12,16 @@ The following resources will be deployed when using the provided example:
 
 Create a `terraform.tfvars` file and copy the content of `example.tfvars` into it, adjust the variables (in particular the `storage_account_name` should be unique).
 
-```bash
-$ terraform init
-$ terraform apply
+```sh
+terraform init
+terraform apply
+terraform output -json
+```
+
+## Cleanup
+
+```sh
+terraform destroy
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/bootstrap/README.md
+++ b/examples/bootstrap/README.md
@@ -29,7 +29,7 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.15 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.16 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>2.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~>3.0 |
 

--- a/examples/bootstrap/outputs.tf
+++ b/examples/bootstrap/outputs.tf
@@ -1,24 +1,29 @@
 output "storage_account_name" {
   description = "Name of the Azure Storage Account object used for the Bootstrap."
   value       = module.bootstrap.storage_account.name
+  sensitive   = true
 }
 
 output "storage_account_id" {
   description = "Identifier of the Azure Storage Account object used for the Bootstrap."
   value       = module.bootstrap.storage_account.id
+  sensitive   = true
 }
 
 output "storage_share_name" {
   description = "Name of the File Share within Azure Storage."
   value       = module.bootstrap.storage_share.name
+  sensitive   = true
 }
 
 output "storage_share_id" {
   description = "Identifier of the File Share within Azure Storage."
   value       = module.bootstrap.storage_share.id
+  sensitive   = true
 }
 
 output "primary_access_key" {
   description = "The primary access key for the Azure Storage Account."
   value       = module.bootstrap.primary_access_key
+  sensitive   = true
 }

--- a/examples/bootstrap/versions.tf
+++ b/examples/bootstrap/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.29, <0.15"
+  required_version = ">=0.12.29, <0.16"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/panorama/README.md
+++ b/examples/panorama/README.md
@@ -18,7 +18,7 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.13, <0.15 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.13, <0.16 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>2.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~>3.0 |
 

--- a/examples/panorama/outputs.tf
+++ b/examples/panorama/outputs.tf
@@ -6,6 +6,7 @@ output "panorama_url" {
 output "panorama_admin_password" {
   description = "Panorama administrator's initial password."
   value       = random_password.this.result
+  sensitive   = true
 }
 
 output "username" {

--- a/examples/panorama/versions.tf
+++ b/examples/panorama/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.13, <0.15"
+  required_version = ">=0.13, <0.16"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/transit_vnet_common/README.md
+++ b/examples/transit_vnet_common/README.md
@@ -17,14 +17,14 @@ $ terraform apply
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.13, <0.16 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | =2.42 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | =2.58 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~>3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | =2.42 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | =2.58 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~>3.0 |
 
 ## Modules
@@ -41,9 +41,9 @@ $ terraform apply
 
 | Name | Type |
 |------|------|
-| [azurerm_network_security_rule.mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/2.42/docs/resources/network_security_rule) | resource |
-| [azurerm_public_ip.public](https://registry.terraform.io/providers/hashicorp/azurerm/2.42/docs/resources/public_ip) | resource |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.42/docs/resources/resource_group) | resource |
+| [azurerm_network_security_rule.mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/2.58/docs/resources/network_security_rule) | resource |
+| [azurerm_public_ip.public](https://registry.terraform.io/providers/hashicorp/azurerm/2.58/docs/resources/public_ip) | resource |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.58/docs/resources/resource_group) | resource |
 | [random_password.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 
 ## Inputs

--- a/examples/transit_vnet_common/README.md
+++ b/examples/transit_vnet_common/README.md
@@ -16,7 +16,7 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.13, <0.15 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.13, <0.16 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | =2.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~>3.0 |
 

--- a/examples/transit_vnet_common/outputs.tf
+++ b/examples/transit_vnet_common/outputs.tf
@@ -6,6 +6,7 @@ output "username" {
 output "password" {
   description = "Initial administrative password to use for VM-Series."
   value       = coalesce(var.password, random_password.this.result)
+  sensitive   = true
 }
 
 output mgmt_ip_addresses {

--- a/examples/transit_vnet_common/versions.tf
+++ b/examples/transit_vnet_common/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.42"
+      version = "=2.58"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/transit_vnet_common/versions.tf
+++ b/examples/transit_vnet_common/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.13, <0.15"
+  required_version = ">=0.13, <0.16"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/vmseries_scaleset/README.md
+++ b/examples/vmseries_scaleset/README.md
@@ -19,14 +19,14 @@ $ terraform apply
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.16 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>2.42 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | =2.58 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~>3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~>2.42 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | =2.58 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~>3.0 |
 
 ## Modules
@@ -45,8 +45,8 @@ $ terraform apply
 
 | Name | Type |
 |------|------|
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
-| [azurerm_storage_container.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.58/docs/resources/resource_group) | resource |
+| [azurerm_storage_container.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.58/docs/resources/storage_container) | resource |
 | [random_password.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 
 ## Inputs

--- a/examples/vmseries_scaleset/README.md
+++ b/examples/vmseries_scaleset/README.md
@@ -18,7 +18,7 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.15 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.16 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>2.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~>3.0 |
 

--- a/examples/vmseries_scaleset/outputs.tf
+++ b/examples/vmseries_scaleset/outputs.tf
@@ -6,4 +6,5 @@ output "USERNAME" {
 output "PASSWORD" {
   description = "PAN Device password"
   value       = random_password.this.result
+  sensitive   = true
 }

--- a/examples/vmseries_scaleset/versions.tf
+++ b/examples/vmseries_scaleset/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>2.42"
+      version = "=2.58"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/vmseries_scaleset/versions.tf
+++ b/examples/vmseries_scaleset/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.29, <0.15"
+  required_version = ">=0.12.29, <0.16"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/vnet/README.md
+++ b/examples/vnet/README.md
@@ -19,13 +19,13 @@ $ terraform apply
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.16 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=2.26.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | =2.58 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >=2.26.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | =2.58 |
 
 ## Modules
 
@@ -37,7 +37,7 @@ $ terraform apply
 
 | Name | Type |
 |------|------|
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.58/docs/resources/resource_group) | resource |
 
 ## Inputs
 

--- a/examples/vnet/README.md
+++ b/examples/vnet/README.md
@@ -18,7 +18,7 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.15 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.16 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=2.26.0 |
 
 ## Providers

--- a/examples/vnet/main.tf
+++ b/examples/vnet/main.tf
@@ -1,13 +1,7 @@
-# Greenfield deployment
-provider "azurerm" {
-  version = ">=2.26.0"
-  features {}
-}
-
 resource "azurerm_resource_group" "this" {
   name     = var.resource_group_name
   location = var.location
-  tags     = {}
+  tags     = var.tags
 }
 
 module "vnet" {

--- a/examples/vnet/versions.tf
+++ b/examples/vnet/versions.tf
@@ -1,3 +1,13 @@
 terraform {
   required_version = ">=0.12.29, <0.16"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=2.58"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
 }

--- a/examples/vnet/versions.tf
+++ b/examples/vnet/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">=0.12.29, <0.15"
+  required_version = ">=0.12.29, <0.16"
 }

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -14,7 +14,7 @@ See the examples/vm-series directory.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.15 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.16 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>2.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~>3.0 |
 

--- a/modules/bootstrap/outputs.tf
+++ b/modules/bootstrap/outputs.tf
@@ -1,14 +1,17 @@
 output "storage_account" {
   description = "The Azure Storage Account object used for the Bootstrap."
   value       = local.storage_account
+  sensitive   = true
 }
 
 output "storage_share" {
   description = "The File Share object within Azure Storage used for the Bootstrap."
   value       = azurerm_storage_share.this
+  sensitive   = true
 }
 
 output "primary_access_key" {
   description = "The primary access key for the Azure Storage Account."
   value       = local.storage_account.primary_access_key
+  sensitive   = true
 }

--- a/modules/bootstrap/versions.tf
+++ b/modules/bootstrap/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.29, <0.15"
+  required_version = ">=0.12.29, <0.16"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/loadbalancer/README.md
+++ b/modules/loadbalancer/README.md
@@ -61,7 +61,7 @@ module "outbound_lb" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.15 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.16 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>2.42 |
 
 ## Providers

--- a/modules/loadbalancer/README.md
+++ b/modules/loadbalancer/README.md
@@ -62,13 +62,13 @@ module "outbound_lb" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.16 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>2.42 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>2.46 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~>2.42 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~>2.46 |
 
 ## Modules
 

--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -87,9 +87,8 @@ locals {
 }
 
 resource "azurerm_lb_backend_address_pool" "lb_backend" {
-  name                = coalesce(var.backend_name, var.name)
-  resource_group_name = var.resource_group_name
-  loadbalancer_id     = azurerm_lb.lb.id
+  name            = coalesce(var.backend_name, var.name)
+  loadbalancer_id = azurerm_lb.lb.id
 }
 
 resource "azurerm_lb_probe" "probe" {

--- a/modules/loadbalancer/versions.tf
+++ b/modules/loadbalancer/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.29, <0.15"
+  required_version = ">=0.12.29, <0.16"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/loadbalancer/versions.tf
+++ b/modules/loadbalancer/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>2.42"
+      version = "~>2.46"
     }
   }
 }

--- a/modules/panorama/README.md
+++ b/modules/panorama/README.md
@@ -38,7 +38,7 @@ module "panorama" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.15 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.16 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>2.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~>3.0 |
 

--- a/modules/panorama/versions.tf
+++ b/modules/panorama/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.29, <0.15"
+  required_version = ">=0.12.29, <0.16"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -57,7 +57,7 @@ If your Region doesn't, use an alternative mechanism of Availability Set, which 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.15 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.16 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>2.26 |
 
 ## Providers

--- a/modules/vmseries/outputs.tf
+++ b/modules/vmseries/outputs.tf
@@ -16,4 +16,5 @@ output "principal_id" {
 output "metrics_instrumentation_key" {
   description = "The Instrumentation Key of the created instance of Azure Application Insights. The instance is unused by default, but is ready to receive custom PAN-OS metrics from the firewalls. To use it, paste this Instrumentation Key into PAN-OS -> Device -> VM-Series -> Azure."
   value       = try(azurerm_application_insights.this[0].instrumentation_key, null)
+  sensitive   = true
 }

--- a/modules/vmseries/versions.tf
+++ b/modules/vmseries/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.29, <0.15"
+  required_version = ">=0.12.29, <0.16"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/vmss/README.md
+++ b/modules/vmss/README.md
@@ -26,7 +26,7 @@ module "vmss" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.15 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.16 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=2.26.0 |
 
 ## Providers

--- a/modules/vmss/versions.tf
+++ b/modules/vmss/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.29, <0.15"
+  required_version = ">=0.12.29, <0.16"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/vnet/README.md
+++ b/modules/vnet/README.md
@@ -31,7 +31,7 @@ module "vnet" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.15 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.16 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>2.26 |
 
 ## Providers

--- a/modules/vnet/versions.tf
+++ b/modules/vnet/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.29, <0.15"
+  required_version = ">=0.12.29, <0.16"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
## Description

### feat: Mark selected outputs as sensitive

Pass the `sensitive` status marked by providers onto the outputs. This
will be a hard requirement from Terraform version 0.15 onwards.

The sensitive outputs are best viewed with `-json` flag.

For docs, remove the `$ ` prompts because of the linting rule:
"MD014/commands-show-output: Dollar signs used before commands without
showing output"

### feat: Allow terraform 0.15.x for all modules and examples

This is the recommended version, so allowing it is a major use case.

### feat(loadbalancer)!: Require azurerm provider version 2.46+

When using provider older than 2.46, it visibly warns:
`"resource_group_name": [DEPRECATED] in resource "azurerm_lb_backend_address_pool"`

Since the examples cannot stay on 2.42 now, pinning them
to the latest version, which is 2.58 (as of now).

It's debatable whether this change is actually Breaking. But for now, I stay on the safe side here.

## How Has This Been Tested?

Apply all the examples.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have marked all the changes that users need to see in the Changelog.
- [x] I have *not* marked the Changelog-unworthy commits as `feat`, `fix`, or `!`.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
