### PR TITLE
feat(examples): Add a minimal vmseries example

### DIFF
--- a/examples/vmseries/README.md
+++ b/examples/vmseries/README.md
@@ -1,5 +1,82 @@
 # Example of `vmseries` Terraform Module on Azure Cloud
 
-The basic example is not available yet.
+The is a very minimal example of the `vmseries` module. It lacks any traffic inspection.
+It creates a single VM-Series with a management-only interface. It can be usable for familiarizing
+oneself with terraform, as well as a bed for creating a custom pan-os image.
 
-To see a full VM-Series module usage, see the example from the directory [../transit_vnet_common](../transit_vnet_common). It deploys one of the VM-Series Reference Architectures in its entirety.
+To see a full VM-Series module usage, see the example from the directory [../transit_vnet_common](../transit_vnet_common). It deploys one of the VM-Series Reference Architectures in its entirety, including load balancing.
+
+## Usage
+
+Create a `terraform.tfvars` file and copy the content of `example.tfvars` into it, adjust if needed.
+
+Then execute:
+
+```sh
+terraform init
+terraform apply
+terraform ouput -json password
+```
+
+Having the `username`, `password`, and `mgmt_ip_addresses`, use them to connect through ssh:
+
+```sh
+ssh <username>@<mgmt_ip_addresses>
+```
+
+## Cleanup
+
+To delete all the resources created by the previous `apply` attempts, execute:
+
+```sh
+terraform destroy
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.12.29, <0.16 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | =2.58 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~>3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | =2.58 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~>3.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_vmseries"></a> [vmseries](#module\_vmseries) | ../../modules/vmseries |  |
+| <a name="module_vnet"></a> [vnet](#module\_vnet) | ../../modules/vnet |  |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.58/docs/resources/resource_group) | resource |
+| [random_password.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allow_inbound_mgmt_ips"></a> [allow\_inbound\_mgmt\_ips](#input\_allow\_inbound\_mgmt\_ips) | List of IP CIDR ranges (like `["23.23.23.23"]`) that are allowed to access management interfaces of VM-Series.<br>If you use Panorama, include its address in the list (as well as the secondary Panorama's). | `list(string)` | n/a | yes |
+| <a name="input_common_vmseries_sku"></a> [common\_vmseries\_sku](#input\_common\_vmseries\_sku) | VM-Series SKU, for example `bundle1`, or `bundle2`. If it is `byol`, the VM-Series starts unlicensed. | `string` | n/a | yes |
+| <a name="input_location"></a> [location](#input\_location) | The Azure region to use. | `string` | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the Resource Group to create. | `string` | n/a | yes |
+| <a name="input_username"></a> [username](#input\_username) | Initial administrative username. Mind the [Azure-imposed restrictions](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-username-requirements-when-creating-a-vm). | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_mgmt_ip_addresses"></a> [mgmt\_ip\_addresses](#output\_mgmt\_ip\_addresses) | IP Addresses for VM-Series management (https or ssh). |
+| <a name="output_password"></a> [password](#output\_password) | Initial administrative password to use for VM-Series. |
+| <a name="output_username"></a> [username](#output\_username) | Initial administrative username to use for VM-Series. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/vmseries/example.tfvars
+++ b/examples/vmseries/example.tfvars
@@ -3,6 +3,6 @@ resource_group_name = "example-rg"
 common_vmseries_sku = "bundle1"
 username            = "panadmin"
 allow_inbound_mgmt_ips = [
-  "191.191.191.191", # Put your own public IP address here
+  "191.191.191.191", # Put your own public IP address here, visit "https://ifconfig.me/"
   "10.255.0.0/24",   # Example Panorama access
 ]

--- a/examples/vmseries/example.tfvars
+++ b/examples/vmseries/example.tfvars
@@ -1,9 +1,8 @@
-location            = "East US 2"
+location            = "Australia East"
 resource_group_name = "example-rg"
 common_vmseries_sku = "bundle1"
 username            = "panadmin"
 allow_inbound_mgmt_ips = [
   "191.191.191.191", # Put your own public IP address here
   "10.255.0.0/24",   # Example Panorama access
-  # "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16",
 ]

--- a/examples/vmseries/example.tfvars
+++ b/examples/vmseries/example.tfvars
@@ -1,0 +1,9 @@
+location            = "East US 2"
+resource_group_name = "example-rg"
+common_vmseries_sku = "bundle1"
+username            = "panadmin"
+allow_inbound_mgmt_ips = [
+  "191.191.191.191", # Put your own public IP address here
+  "10.255.0.0/24",   # Example Panorama access
+  # "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16",
+]

--- a/examples/vmseries/main.tf
+++ b/examples/vmseries/main.tf
@@ -42,7 +42,7 @@ module "vnet" {
   subnets = {
     "subnet-mgmt" = {
       address_prefixes       = ["10.110.255.0/24"]
-      network_security_group = "sg-mgmt"
+      network_security_group = "management-security-group"
     }
   }
 }

--- a/examples/vmseries/main.tf
+++ b/examples/vmseries/main.tf
@@ -23,7 +23,7 @@ module "vnet" {
   resource_group_name  = azurerm_resource_group.this.name
   address_space        = ["10.110.0.0/16"]
   network_security_groups = {
-    "sg-mgmt" = {
+    "management-security-group" = {
       rules = {
         "vm-management-rules" = {
           access                     = "Allow"

--- a/examples/vmseries/main.tf
+++ b/examples/vmseries/main.tf
@@ -1,0 +1,67 @@
+# Resource group to hold all resources
+resource "azurerm_resource_group" "this" {
+  name     = var.resource_group_name
+  location = var.location
+}
+
+# Generate a random password for VM-Series
+resource "random_password" "this" {
+  length           = 16
+  min_lower        = 16 - 4
+  min_numeric      = 1
+  min_special      = 1
+  min_upper        = 1
+  override_special = "_%@"
+}
+
+# Virtual Network and its Network Security Group
+module "vnet" {
+  source = "../../modules/vnet"
+
+  virtual_network_name = "vnet-vmseries"
+  location             = var.location
+  resource_group_name  = azurerm_resource_group.this.name
+  address_space        = ["10.110.0.0/16"]
+  network_security_groups = {
+    "sg-mgmt" = {
+      rules = {
+        "vm-management-rules" = {
+          access                     = "Allow"
+          direction                  = "Inbound"
+          priority                   = 100
+          protocol                   = "TCP"
+          source_port_range          = "*"
+          source_address_prefixes    = var.allow_inbound_mgmt_ips
+          destination_address_prefix = "*"
+          destination_port_range     = "*"
+        }
+      }
+    }
+  }
+  route_tables = {}
+  subnets = {
+    "subnet-mgmt" = {
+      address_prefixes       = ["10.110.255.0/24"]
+      network_security_group = "sg-mgmt"
+    }
+  }
+}
+
+# The VM-Series virtual machine
+module "vmseries" {
+  source = "../../modules/vmseries"
+
+  location            = var.location
+  resource_group_name = azurerm_resource_group.this.name
+  name                = "myfw"
+  username            = var.username
+  password            = random_password.this.result
+  img_sku             = var.common_vmseries_sku
+  interfaces = [
+    {
+      name             = "myfw-mgmt"
+      subnet_id        = lookup(module.vnet.subnet_ids, "subnet-mgmt", null)
+      create_public_ip = true
+    },
+  ]
+}

--- a/examples/vmseries/outputs.tf
+++ b/examples/vmseries/outputs.tf
@@ -1,0 +1,15 @@
+output "username" {
+  description = "Initial administrative username to use for VM-Series."
+  value       = var.username
+}
+
+output "password" {
+  description = "Initial administrative password to use for VM-Series."
+  value       = random_password.this.result
+  sensitive   = true
+}
+
+output "mgmt_ip_addresses" {
+  description = "IP Addresses for VM-Series management (https or ssh)."
+  value       = module.vmseries.mgmt_ip_address
+}

--- a/examples/vmseries/variables.tf
+++ b/examples/vmseries/variables.tf
@@ -1,0 +1,27 @@
+variable "location" {
+  description = "The Azure region to use."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Name of the Resource Group to create."
+  type        = string
+}
+
+variable "username" {
+  description = "Initial administrative username. Mind the [Azure-imposed restrictions](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-username-requirements-when-creating-a-vm)."
+  type        = string
+}
+
+variable "allow_inbound_mgmt_ips" {
+  description = <<-EOF
+    List of IP CIDR ranges (like `["23.23.23.23"]`) that are allowed to access management interfaces of VM-Series.
+    If you use Panorama, include its address in the list (as well as the secondary Panorama's).
+  EOF
+  type        = list(string)
+}
+
+variable "common_vmseries_sku" {
+  description = "VM-Series SKU, for example `bundle1`, or `bundle2`. If it is `byol`, the VM-Series starts unlicensed."
+  type        = string
+}

--- a/examples/vmseries/versions.tf
+++ b/examples/vmseries/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">=0.12.29, <0.16"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=2.58"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~>3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -9,12 +9,11 @@ The module is not intended for use with Scale Sets.
 module "vmseries" {
   source  = "../../modules/vmseries"
 
-  location                      = "Australia Central"
-  name                          = "my-firewall"
-  password                      = "change-me-XOX0"
-  bootstrap_storage_account     = module.vm-bootstrap.bootstrap_storage_account
-  bootstrap_share_name          = "sharename"
-  subnet_mgmt                   = module.networks.subnet_mgmt
+  location            = "Australia East"
+  resource_group_name = azurerm_resource_group.this.name
+  name                = "myfw"
+  username            = "panadmin"
+  password            = "Change-Me-007"
   interfaces = [
     {
       name      = "myfw-mgmt-interface"

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -17,12 +17,8 @@ module "vmseries" {
   subnet_mgmt                   = module.networks.subnet_mgmt
   interfaces = [
     {
-      subnet              = module.networks.subnet_public
-      enable_backend_pool = false
-    },
-    {
-      subnet              = module.networks.subnet_private
-      enable_backend_pool = false
+      name      = "myfw-mgmt-interface"
+      subnet_id = lookup(module.vnet.subnet_ids, "subnet-mgmt", null)
     },
   ]
 }

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -42,7 +42,7 @@ resource "azurerm_virtual_machine" "this" {
   resource_group_name          = var.resource_group_name
   tags                         = var.tags
   vm_size                      = var.vm_size
-  zones                        = var.avzone != null ? [var.avzone] : null
+  zones                        = var.avzone != null && var.avzone != "" ? [var.avzone] : null
   availability_set_id          = var.avset_id
   primary_network_interface_id = azurerm_network_interface.this[0].id
 


### PR DESCRIPTION
## Description

### feat(examples): Add a minimal vmseries example

Create a very minimal example. It's the only one which is 0.12.29
compatible, because it does not employ module `depends_on` or module
`for_each` anywhere.

As this example is not intended to be copy-pasted into maintainable
codebases, a majority of usual variables are inlined into the main.tf
code. This way users see everything together, which can aid their
learning.

### feat(vmseries): Allow input avzone to be an empty string

When avzone is an empty string, treat it the same as null.

### Docs

docs(vmseries): fix usage in the README 

## How Has This Been Tested?

`apply` per example's instruction

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
