### PR TITLE
bug: Add missing folder in bootstrap module (TERRAM-112)

### DIFF
--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -30,7 +30,9 @@ resource "azurerm_storage_share_directory" "nonconfig" {
   for_each = toset([
     "content",
     "software",
-  "license"])
+    "plugins",
+    "license"
+  ])
 
   name                 = each.key
   share_name           = azurerm_storage_share.this.name


### PR DESCRIPTION
Bootstrap module didn't create plugins/ folder described here: https://docs.paloaltonetworks.com/vm-series/9-0/vm-series-deployment/bootstrap-the-vm-series-firewall/prepare-the-bootstrap-package.html
