### PR TITLE
fix a bug in examples/transit_vnet_dedicated

### DIFF
--- a/examples/transit_vnet_dedicated/main.tf
+++ b/examples/transit_vnet_dedicated/main.tf
@@ -181,8 +181,8 @@ module "outbound_vmseries" {
   vm_size                   = var.outbound_vmseries_vm_size
   tags                      = var.outbound_vmseries_tags
   enable_zones              = var.enable_zones
-  bootstrap_storage_account = module.bootstrap.storage_account
-  bootstrap_share_name      = module.bootstrap.storage_share.name
+  bootstrap_storage_account = module.outbound_bootstrap.storage_account
+  bootstrap_share_name      = module.outbound_bootstrap.storage_share.name
   interfaces = [
     {
       name                = "${each.key}-mgmt"


### PR DESCRIPTION
## Description

Correct the files used for bootstrapping outbound VM-Series.

## Motivation and Context

Previously the same storage account was used for outbound VM-Series as for the inbound. Ouch. 😖 

## How Has This Been Tested?

Create a `terraform.tfvars` file and copy the content of `example.tfvars` into it, adjust if needed. Use Panorama. Make sure the outbound firewalls have configured different `dgname` than inbound firewalls.

```sh
terraform init
terraform apply
terraform ouput -json password
# On Panorama, make sure the outbound firewalls used different dgname than inbound firewalls.
terraform destory
```

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
