### PR TITLE
fix(vmseries): disallow IP forwarding through the mgmt interface

### DIFF
--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -25,7 +25,7 @@ resource "azurerm_network_interface" "this" {
   location                      = var.location
   resource_group_name           = var.resource_group_name
   enable_accelerated_networking = count.index == 0 ? false : var.accelerated_networking # for interface 0 it is unsupported by PAN-OS
-  enable_ip_forwarding          = true
+  enable_ip_forwarding          = count.index == 0 ? false : true                       # for interface 0 use false per Reference Arch
   tags                          = try(var.interfaces[count.index].tags, var.tags)
 
   ip_configuration {


### PR DESCRIPTION
## Description

Prevent the first network interface (the management intrface) from
receiving packets with a non-matching destination IP address.

## Motivation and Context

This is per recommendation of the official Reference Architecture. Also,
there are currently no known use cases which would require that.

## How Has This Been Tested?

By `apply` and `destroy -parallelism 1` of examples per their READMEs.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

While this change is technically a breaking one for anyone who uses the first interface for packet
forwarding (for example as a next hop in Azure route table), it's hard to come up with any real
environment or use-case that would be using this today in the field.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
