### PR TITLE
Adding support for Public IP Prefix in VMSS

### DIFF
--- a/modules/vmss/main.tf
+++ b/modules/vmss/main.tf
@@ -83,6 +83,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
           name                    = "${var.name_prefix}${var.name_fw_mgmt_pip}"
           domain_name_label       = var.mgmt_pip_domain_name_label
           idle_timeout_in_minutes = 4
+          public_ip_prefix_id     = var.public_ip_prefix_id
         }
       }
     }

--- a/modules/vmss/variables.tf
+++ b/modules/vmss/variables.tf
@@ -44,6 +44,11 @@ variable "create_public_pip" {
   type    = bool
 }
 
+variable "public_ip_prefix_id" {
+  default = null
+  type    = string
+}
+
 variable "mgmt_pip_domain_name_label" {
   default = null
   type    = string


### PR DESCRIPTION
## Description
Added public ip prefix variable in variables.tf file and main.tf

## Motivation and Context
Static IP prefix is needed for outbound traffic when you want to allow the traffic through ACL. 

## How Has This Been Tested?
Added the small changes to my code, and then deployed it to azure.
Have not tested it without any given value.

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
