### PR TITLE
ci: fix GH release link

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -31,7 +31,7 @@
         [
             "@semantic-release/github",
             {
-                "successComment": ":tada: This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version} :tada:\n\nThe release is available on [Terraform Registry](https://registry.terraform.io/modules/PaloAltoNetworks/vmseries-modules/azurerm/latest) and [GitHub release](<github_release_url>)\n\n> Posted by [semantic-release](https://github.com/semantic-release/semantic-release) bot"
+                "successComment": ":tada: This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version} :tada:\n\nThe release is available on [Terraform Registry](https://registry.terraform.io/modules/PaloAltoNetworks/vmseries-modules/azurerm/latest) and [GitHub release](../releases/tag/v${nextRelease.version})\n\n> Posted by [semantic-release](https://github.com/semantic-release/semantic-release) bot"
             }
         ]
     ],


### PR DESCRIPTION
## Description

The current GH release links are pointing to a dead link

Example: https://github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules/pull/127#issuecomment-949645618

