### PR TITLE
refactor(vnet)!: moving ngs rules management into nsg resource

### DIFF
--- a/VNET-NSG-testing-scenarios.md
+++ b/VNET-NSG-testing-scenarios.md
@@ -1,0 +1,420 @@
+
+# Test outcome
+
+for [PR](https://github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules/pull/138)
+
+The plan for testing is:
+
+<!-- vscode-markdown-toc -->
+* [entry point](#entrypoint)
+* [adding a rule in the middle](#addingaruleinthemiddle)
+* [change order of rules](#changeorderofrules)
+* [delete the 1<sup>st</sup> rule](#deletethe1supstsuprule)
+* [conclusion](#conclusion)
+
+<!-- vscode-markdown-toc-config
+	numbering=false
+	autoSave=false
+	/vscode-markdown-toc-config -->
+<!-- /vscode-markdown-toc -->
+
+
+## <a name='entrypoint'></a>entry point
+
+created two rules like this:
+
+```hcl
+network_security_groups = {
+  "network_security_group_1" = {
+    location = "North Europe"
+    rules = {
+      "AllOutbound" = {
+        priority                   = 100
+        direction                  = "Outbound"
+        protocol                   = "Tcp"
+        access                     = "Allow"
+        source_port_range          = "*"
+        destination_port_range     = "*"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+      "AllowSSH" = {
+        priority                   = 200
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "22"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      }
+    }
+  }
+}
+```
+
+## <a name='addingaruleinthemiddle'></a>adding a rule in the middle
+
+adding one more rule, so the rules look like this:
+
+``` hcl
+network_security_groups = {
+  "network_security_group_1" = {
+    location = "North Europe"
+    rules = {
+      "AllOutbound" = {
+        priority                   = 100
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "*"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+      "AllowRDP" = {
+        priority                   = 300
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "3389"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      }
+      "AllowSSH" = {
+        priority                   = 200
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "22"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      }
+    }
+  }
+}
+```
+
+after running `terraform plan` following output is shown
+```bash
+Terraform will perform the following actions:
+
+  # module.vnet.azurerm_network_security_group.this["network_security_group_1"] will be updated in-place
+  ~ resource "azurerm_network_security_group" "this" {
+        id                  = "/subscriptions/d47f1af8-9795-4e86-bbce-da72cfd0f8ec/resourceGroups/fosix-vnet-test/providers/Microsoft.Network/networkSecurityGroups/network_security_group_1"
+        name                = "network_security_group_1"
+      ~ security_rule       = [
+          - {
+              - access                                     = "Allow"
+              - description                                = ""
+              - destination_address_prefix                 = "*"
+              - destination_address_prefixes               = []
+              - destination_application_security_group_ids = []
+              - destination_port_range                     = "*"
+              - destination_port_ranges                    = []
+              - direction                                  = "Outbound"
+              - name                                       = "AllOutbound"
+              - priority                                   = 100
+              - protocol                                   = "Tcp"
+              - source_address_prefix                      = "*"
+              - source_address_prefixes                    = []
+              - source_application_security_group_ids      = []
+              - source_port_range                          = "*"
+              - source_port_ranges                         = []
+            },
+          - {
+              - access                                     = "Allow"
+              - description                                = ""
+              - destination_address_prefix                 = "*"
+              - destination_address_prefixes               = []
+              - destination_application_security_group_ids = []
+              - destination_port_range                     = "22"
+              - destination_port_ranges                    = []
+              - direction                                  = "Inbound"
+              - name                                       = "AllowSSH"
+              - priority                                   = 200
+              - protocol                                   = "Tcp"
+              - source_address_prefix                      = "*"
+              - source_address_prefixes                    = []
+              - source_application_security_group_ids      = []
+              - source_port_range                          = "*"
+              - source_port_ranges                         = []
+            },
+          + {
+              + access                                     = "Allow"
+              + description                                = ""
+              + destination_address_prefix                 = "*"
+              + destination_address_prefixes               = []
+              + destination_application_security_group_ids = []
+              + destination_port_range                     = "3389"
+              + destination_port_ranges                    = []
+              + direction                                  = "Inbound"
+              + name                                       = "AllowRDP"
+              + priority                                   = 300
+              + protocol                                   = "Tcp"
+              + source_address_prefix                      = "*"
+              + source_address_prefixes                    = []
+              + source_application_security_group_ids      = []
+              + source_port_range                          = "*"
+              + source_port_ranges                         = []
+            },
+          + {
+              + access                                     = "Allow"
+              + description                                = null
+              + destination_address_prefix                 = "*"
+              + destination_address_prefixes               = []
+              + destination_application_security_group_ids = []
+              + destination_port_range                     = "*"
+              + destination_port_ranges                    = []
+              + direction                                  = "Outbound"
+              + name                                       = "AllOutbound"
+              + priority                                   = 100
+              + protocol                                   = "Tcp"
+              + source_address_prefix                      = "*"
+              + source_address_prefixes                    = []
+              + source_application_security_group_ids      = []
+              + source_port_range                          = "*"
+              + source_port_ranges                         = []
+            },
+          + {
+              + access                                     = "Allow"
+              + description                                = null
+              + destination_address_prefix                 = "*"
+              + destination_address_prefixes               = []
+              + destination_application_security_group_ids = []
+              + destination_port_range                     = "22"
+              + destination_port_ranges                    = []
+              + direction                                  = "Inbound"
+              + name                                       = "AllowSSH"
+              + priority                                   = 200
+              + protocol                                   = "Tcp"
+              + source_address_prefix                      = "*"
+              + source_address_prefixes                    = []
+              + source_application_security_group_ids      = []
+              + source_port_range                          = "*"
+              + source_port_ranges                         = []
+            },
+        ]
+        tags                = {
+            "owner" = "fosix"
+        }
+        # (2 unchanged attributes hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+```
+
+The NSG itself will not be recreated, but the whole ruleset 'inside' NSG will be replaced.
+
+## <a name='changeorderofrules'></a>change order of rules
+
+The input is the same as in the [adding a rule in the middle](adding a rule in the middle), just the order of rules is different. The set of rules from [adding a rule in the middle](adding a rule in the middle) has bwwn already applied to Azure, hence the output of the `terraform plan` command reflects only the order change.
+
+```hcl
+network_security_groups = {
+  "network_security_group_1" = {
+    location = "North Europe"
+    rules = {
+      "AllowSSH" = {
+        priority                   = 200
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "22"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      }
+      "AllowRDP" = {
+        priority                   = 300
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "3389"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      }
+      "AllOutbound" = {
+        priority                   = 100
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "*"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+    }
+  }
+}
+```
+
+Below is the `terraform plan` output:
+
+```bash
+azurerm_resource_group.this: Refreshing state... [id=/subscriptions/d47f1af8-9795-4e86-bbce-da72cfd0f8ec/resourceGroups/fosix-vnet-test]
+module.vnet.azurerm_route_table.this["route_table_1"]: Refreshing state... [id=/subscriptions/d47f1af8-9795-4e86-bbce-da72cfd0f8ec/resourceGroups/fosix-vnet-test/providers/Microsoft.Network/routeTables/route_table_1]
+module.vnet.azurerm_virtual_network.this[0]: Refreshing state... [id=/subscriptions/d47f1af8-9795-4e86-bbce-da72cfd0f8ec/resourceGroups/fosix-vnet-test/providers/Microsoft.Network/virtualNetworks/fosix-vnet-nsg-test]
+module.vnet.azurerm_network_security_group.this["network_security_group_1"]: Refreshing state... [id=/subscriptions/d47f1af8-9795-4e86-bbce-da72cfd0f8ec/resourceGroups/fosix-vnet-test/providers/Microsoft.Network/networkSecurityGroups/network_security_group_1]
+module.vnet.azurerm_subnet.this["management"]: Refreshing state... [id=/subscriptions/d47f1af8-9795-4e86-bbce-da72cfd0f8ec/resourceGroups/fosix-vnet-test/providers/Microsoft.Network/virtualNetworks/fosix-vnet-nsg-test/subnets/management]
+module.vnet.azurerm_subnet_network_security_group_association.this["management"]: Refreshing state... [id=/subscriptions/d47f1af8-9795-4e86-bbce-da72cfd0f8ec/resourceGroups/fosix-vnet-test/providers/Microsoft.Network/virtualNetworks/fosix-vnet-nsg-test/subnets/management]
+
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
+```
+
+Hence, the order of the rules does not matter, only the content of the whole set of rules. 
+
+## <a name='deletethe1supstsuprule'></a>delete the 1<sup>st</sup> rule
+
+Just like the topic says, input rules:
+
+```hcl
+network_security_groups = {
+  "network_security_group_1" = {
+    location = "North Europe"
+    rules = {
+      "AllowRDP" = {
+        priority                   = 300
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "3389"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      }
+      "AllOutbound" = {
+        priority                   = 100
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "*"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      },
+    }
+  }
+}
+```
+
+`terrafrom plan` output:
+
+```bash
+Terraform will perform the following actions:
+
+  # module.vnet.azurerm_network_security_group.this["network_security_group_1"] will be updated in-place
+  ~ resource "azurerm_network_security_group" "this" {
+        id                  = "/subscriptions/d47f1af8-9795-4e86-bbce-da72cfd0f8ec/resourceGroups/fosix-vnet-test/providers/Microsoft.Network/networkSecurityGroups/network_security_group_1"
+        name                = "network_security_group_1"
+      ~ security_rule       = [
+          - {
+              - access                                     = "Allow"
+              - description                                = ""
+              - destination_address_prefix                 = "*"
+              - destination_address_prefixes               = []
+              - destination_application_security_group_ids = []
+              - destination_port_range                     = "*"
+              - destination_port_ranges                    = []
+              - direction                                  = "Outbound"
+              - name                                       = "AllOutbound"
+              - priority                                   = 100
+              - protocol                                   = "Tcp"
+              - source_address_prefix                      = "*"
+              - source_address_prefixes                    = []
+              - source_application_security_group_ids      = []
+              - source_port_range                          = "*"
+              - source_port_ranges                         = []
+            },
+          - {
+              - access                                     = "Allow"
+              - description                                = ""
+              - destination_address_prefix                 = "*"
+              - destination_address_prefixes               = []
+              - destination_application_security_group_ids = []
+              - destination_port_range                     = "22"
+              - destination_port_ranges                    = []
+              - direction                                  = "Inbound"
+              - name                                       = "AllowSSH"
+              - priority                                   = 200
+              - protocol                                   = "Tcp"
+              - source_address_prefix                      = "*"
+              - source_address_prefixes                    = []
+              - source_application_security_group_ids      = []
+              - source_port_range                          = "*"
+              - source_port_ranges                         = []
+            },
+          - {
+              - access                                     = "Allow"
+              - description                                = ""
+              - destination_address_prefix                 = "*"
+              - destination_address_prefixes               = []
+              - destination_application_security_group_ids = []
+              - destination_port_range                     = "3389"
+              - destination_port_ranges                    = []
+              - direction                                  = "Inbound"
+              - name                                       = "AllowRDP"
+              - priority                                   = 300
+              - protocol                                   = "Tcp"
+              - source_address_prefix                      = "*"
+              - source_address_prefixes                    = []
+              - source_application_security_group_ids      = []
+              - source_port_range                          = "*"
+              - source_port_ranges                         = []
+            },
+          + {
+              + access                                     = "Allow"
+              + description                                = null
+              + destination_address_prefix                 = "*"
+              + destination_address_prefixes               = []
+              + destination_application_security_group_ids = []
+              + destination_port_range                     = "*"
+              + destination_port_ranges                    = []
+              + direction                                  = "Outbound"
+              + name                                       = "AllOutbound"
+              + priority                                   = 100
+              + protocol                                   = "Tcp"
+              + source_address_prefix                      = "*"
+              + source_address_prefixes                    = []
+              + source_application_security_group_ids      = []
+              + source_port_range                          = "*"
+              + source_port_ranges                         = []
+            },
+          + {
+              + access                                     = "Allow"
+              + description                                = null
+              + destination_address_prefix                 = "*"
+              + destination_address_prefixes               = []
+              + destination_application_security_group_ids = []
+              + destination_port_range                     = "3389"
+              + destination_port_ranges                    = []
+              + direction                                  = "Inbound"
+              + name                                       = "AllowRDP"
+              + priority                                   = 300
+              + protocol                                   = "Tcp"
+              + source_address_prefix                      = "*"
+              + source_address_prefixes                    = []
+              + source_application_security_group_ids      = []
+              + source_port_range                          = "*"
+              + source_port_ranges                         = []
+            },
+        ]
+        tags                = {
+            "owner" = "fosix"
+        }
+        # (2 unchanged attributes hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+```
+
+Just like with adding rules, the whole set is replaced. 
+
+## <a name='conclusion'></a>conclusion
+
+It looks like the whole set of rules is treated like an entity. This is coherent with the AzureRM API where you specify a list of rules as a single parameter. The order of the rules does not matter, only the content. 

--- a/modules/vnet/README.md
+++ b/modules/vnet/README.md
@@ -43,7 +43,6 @@ No modules.
 | Name | Type |
 |------|------|
 | [azurerm_network_security_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group) | resource |
-| [azurerm_network_security_rule.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
 | [azurerm_route.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/route) | resource |
 | [azurerm_route_table.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/route_table) | resource |
 | [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |

--- a/modules/vnet/main.tf
+++ b/modules/vnet/main.tf
@@ -28,14 +28,14 @@ resource "azurerm_subnet" "this" {
   address_prefixes     = each.value.address_prefixes
 }
 
-resource "azurerm_network_security_group" "this" {
-  for_each = var.network_security_groups
+# resource "azurerm_network_security_group" "this" {
+#   for_each = var.network_security_groups
 
-  name                = each.key
-  location            = try(each.value.location, var.location)
-  resource_group_name = var.resource_group_name
-  tags                = var.tags
-}
+#   name                = each.key
+#   location            = try(each.value.location, var.location)
+#   resource_group_name = var.resource_group_name
+#   tags                = var.tags
+# }
 
 locals {
   nsg_rules = flatten([
@@ -49,24 +49,33 @@ locals {
   ])
 }
 
-resource "azurerm_network_security_rule" "this" {
-  for_each = {
-    for nsg in local.nsg_rules : "${nsg.nsg_name}-${nsg.name}" => nsg
+resource "azurerm_network_security_group" "this" {
+  for_each = var.network_security_groups
+
+  name                = each.key
+  location            = try(each.value.location, var.location)
+  resource_group_name = var.resource_group_name
+  tags                = var.tags
+
+
+  dynamic "security_rule" {
+    for_each = each.value.rules
+
+    content {
+      name                         = security_rule.key
+      priority                     = security_rule.value.priority
+      direction                    = security_rule.value.direction
+      access                       = security_rule.value.access
+      protocol                     = security_rule.value.protocol
+      source_port_range            = security_rule.value.source_port_range
+      destination_port_range       = security_rule.value.destination_port_range
+      source_address_prefix        = lookup(security_rule.value, "source_address_prefix", null)
+      source_address_prefixes      = lookup(security_rule.value, "source_address_prefixes", null)
+      destination_address_prefix   = lookup(security_rule.value, "destination_address_prefix", null)
+      destination_address_prefixes = lookup(security_rule.value, "destination_address_prefixes", null)
+    }
   }
 
-  name                         = each.value.name
-  resource_group_name          = var.resource_group_name
-  network_security_group_name  = azurerm_network_security_group.this[each.value.nsg_name].name
-  priority                     = each.value.rule.priority
-  direction                    = each.value.rule.direction
-  access                       = each.value.rule.access
-  protocol                     = each.value.rule.protocol
-  source_port_range            = each.value.rule.source_port_range
-  destination_port_range       = each.value.rule.destination_port_range
-  source_address_prefix        = lookup(each.value.rule, "source_address_prefix", null)
-  source_address_prefixes      = lookup(each.value.rule, "source_address_prefixes", null)
-  destination_address_prefix   = lookup(each.value.rule, "destination_address_prefix", null)
-  destination_address_prefixes = lookup(each.value.rule, "destination_address_prefixes", null)
 }
 
 resource "azurerm_route_table" "this" {

--- a/modules/vnet/main.tf
+++ b/modules/vnet/main.tf
@@ -28,27 +28,6 @@ resource "azurerm_subnet" "this" {
   address_prefixes     = each.value.address_prefixes
 }
 
-# resource "azurerm_network_security_group" "this" {
-#   for_each = var.network_security_groups
-
-#   name                = each.key
-#   location            = try(each.value.location, var.location)
-#   resource_group_name = var.resource_group_name
-#   tags                = var.tags
-# }
-
-locals {
-  nsg_rules = flatten([
-    for nsg_name, nsg in var.network_security_groups : [
-      for rule_name, rule in lookup(nsg, "rules", {}) : {
-        nsg_name = nsg_name
-        name     = rule_name
-        rule     = rule
-      }
-    ]
-  ])
-}
-
 resource "azurerm_network_security_group" "this" {
   for_each = var.network_security_groups
 

--- a/modules/vnet/main.tf
+++ b/modules/vnet/main.tf
@@ -46,8 +46,10 @@ resource "azurerm_network_security_group" "this" {
       direction                    = security_rule.value.direction
       access                       = security_rule.value.access
       protocol                     = security_rule.value.protocol
-      source_port_range            = security_rule.value.source_port_range
-      destination_port_range       = security_rule.value.destination_port_range
+      source_port_range            = lookup(security_rule.value, "source_port_range", null)
+      source_port_ranges           = lookup(security_rule.value, "source_port_ranges", null)
+      destination_port_range       = lookup(security_rule.value, "destination_port_range", null)
+      destination_port_ranges      = lookup(security_rule.value, "destination_port_ranges", null)
       source_address_prefix        = lookup(security_rule.value, "source_address_prefix", null)
       source_address_prefixes      = lookup(security_rule.value, "source_address_prefixes", null)
       destination_address_prefix   = lookup(security_rule.value, "destination_address_prefix", null)


### PR DESCRIPTION
## Description

Put NSG management into one resource (instead of two: NSG itself and NSG rule separately).

## Motivation and Context

Although there is no change in the module behaviour, the code is:
* cleaner
* easier to understand (no flattening, nested for loops etc)
* represents the structure of the NSG variable (NSG rules are managed inside the NSG resource using `dynamic` block)


## How Has This Been Tested?

Two tests were done:
1. a new VNET was set up using the new module (using the example code) to prove that the module is working
2. a VNET was set up with the old module and then an update was run against that resource with the new module. This showed that this is a *BRAKING* change, meaning that in such situation two runs of terraform are required:
2.1. the 1st one removes the old rules
2.2 the 2nd adds the rules again, but using the new code. 

## Types of changes

- Breaking change as described in [How Has This Been Tested](#types-of-changes)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
