### PR TITLE
fix(module/bootstrap): calculate md5 checksum also for non text files

### DIFF
--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -66,7 +66,7 @@ resource "random_id" "this" {
 
   keepers = {
     # Re-randomize on every content/md5 change. It forcibly recreates all users of this random_id.
-    md5 = try(var.files_md5[each.key], md5(file(each.key)))
+    md5 = try(var.files_md5[each.key], filemd5(each.key))
   }
   byte_length = 8
 }


### PR DESCRIPTION
## Description

The way we calculated md5 checksums for bootstrap files' management was based on `md5` terraform function. This function takes a Unicode string as input. To make it work you have to use a `file` function that 'reads' a file and provides it's content as an output.

This works fine for text files. It does not for binary. 

To fix it a different function `filemd5` was used. It calculates a checksum directly from the file. So it works with both: text and binary files.

## Motivation and Context

Some organisations would like to use bootstrapping for updating (for example) plugins. This is especially important when dealing with ScaleSets and autoscalling (the update is done during bootstrapping). W/O this change it is impossible to manage non-text files using bootstrap module.  


## How Has This Been Tested?

This was tested by creating an infrastructure with bootstrap containing both text and binary files. 

Minimum terraform version used was 0.13

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
