### PR TITLE
feat(vmss): support for public IP prefix for mgmt interface

### DIFF
--- a/modules/vmss/README.md
+++ b/modules/vmss/README.md
@@ -69,6 +69,7 @@ No modules.
 | <a name="input_location"></a> [location](#input\_location) | Region to install VM-Series and dependencies. | `string` | n/a | yes |
 | <a name="input_metrics_retention_in_days"></a> [metrics\_retention\_in\_days](#input\_metrics\_retention\_in\_days) | Specifies the metrics retention period in days. Possible values are 0, 30, 60, 90, 120, 180, 270, 365, 550 or 730. Defaults to 90. A special value 0 disables creation of Application Insights altogether, which is incompatible with `create_autoscaling`. | `number` | `null` | no |
 | <a name="input_mgmt_pip_domain_name_label"></a> [mgmt\_pip\_domain\_name\_label](#input\_mgmt\_pip\_domain\_name\_label) | n/a | `string` | `null` | no |
+| <a name="input_mgmt_pip_prefix_id"></a> [mgmt\_pip\_prefix\_id](#input\_mgmt\_pip\_prefix\_id) | Public IP address prefix id to use for management interface. | `string` | `null` | no |
 | <a name="input_name_application_insights"></a> [name\_application\_insights](#input\_name\_application\_insights) | Name of the Applications Insights instance to be created. Can be null, in which case a default name is auto-generated. | `string` | `null` | no |
 | <a name="input_name_autoscale"></a> [name\_autoscale](#input\_name\_autoscale) | Name of the Autoscale Settings to be created. Can be null, in which case a default name is auto-generated. | `string` | `null` | no |
 | <a name="input_name_fw_mgmt_pip"></a> [name\_fw\_mgmt\_pip](#input\_name\_fw\_mgmt\_pip) | n/a | `string` | `"fw-mgmt-pip"` | no |

--- a/modules/vmss/main.tf
+++ b/modules/vmss/main.tf
@@ -75,6 +75,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
           name                    = "${var.name_prefix}${var.name_fw_mgmt_pip}"
           domain_name_label       = var.mgmt_pip_domain_name_label
           idle_timeout_in_minutes = 4
+          public_ip_prefix_id     = var.mgmt_pip_prefix_id
         }
       }
     }

--- a/modules/vmss/variables.tf
+++ b/modules/vmss/variables.tf
@@ -49,6 +49,12 @@ variable "mgmt_pip_domain_name_label" {
   type    = string
 }
 
+variable "mgmt_pip_prefix_id" {
+  description = "Public IP address prefix id to use for management interface."
+  default     = null
+  type        = string
+}
+
 variable "public_pip_domain_name_label" {
   default = null
   type    = string


### PR DESCRIPTION
## Description

Updates for follwing PR https://github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules/pull/130
Once approved and merged, the original one will be closed.

## Motivation and Context

See linked PR.

## How Has This Been Tested?

Apply using Terraform 1.1.4. Tested without a value in a variable, as well as using an id of existing prefix.

## Screenshots (if appropriate)

n/a

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
