### PR TITLE
chore: Ignore .terraform.lock.hcl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,13 +21,13 @@
 .terrascan
 # Terraform dot files
 .terraform
+.terraform.lock.hcl
 .terraformrc
 **/.terraform/*
 .terraform.d
 *.tfstate
 *.tfstate.*
 .vscode
-.idea
 .idea
 
 # Palo auth codes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,7 @@ repos:
     hooks:
       - id: terraform_fmt 
       - id: terraform_docs
-        # Just avoid "--show providers", because it changes the README each time you do a `terraform init`.
-        args: ['--args=--show=data-sources,footer,header,inputs,modules,outputs,requirements,resources']
+        args: ['--args=--lockfile=false']
       - id: terraform_tflint
         args: [
           --args=--only=terraform_deprecated_interpolation,


### PR DESCRIPTION
## Description

Ignore .terraform.lock.hcl in git and when running terraform-docs.

## Motivation and Context

If the file is taken into account when generating docs it can cause a sort of a "race condition" between local and CI hook executions.

## How Has This Been Tested?

Checked local vs. CI results.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
