### PR TITLE
Feature: Add load balancer output

### DIFF
--- a/modules/loadbalancer/outputs.tf
+++ b/modules/loadbalancer/outputs.tf
@@ -43,3 +43,4 @@ output "health_probe" {
 output "load_balancer" {
   value       = azurerm_lb.lb
   description = "The load balancer object." 
+}

--- a/modules/loadbalancer/outputs.tf
+++ b/modules/loadbalancer/outputs.tf
@@ -39,3 +39,7 @@ output "health_probe" {
   value       = azurerm_lb_probe.probe
   description = "The health probe object."
 }
+
+output "load_balancer" {
+  value       = azurerm_lb.lb
+  description = "The load balancer object." 


### PR DESCRIPTION
Output the load balancer object so the config is more customizable.  For example to set up extra back end pools so you can fail over active active firewalls for upgrades.

## Description

Added an entry in the outputs file to output the load balancer object

## Motivation and Context

This allows for customization, the ability to add more backend pools for manual grace full fail over

## How Has This Been Tested?

This is only an out put so shouldn't effect any other code. I cloned the repo and tested and it worked for me.

## Screenshots (if appropriate)


## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [ x] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes if appropriate.
- [ x] All new and existing tests passed.
