### PR TITLE
docs: Update autogenerated READMEs

### DIFF
--- a/examples/bootstrap/README.md
+++ b/examples/bootstrap/README.md
@@ -33,6 +33,12 @@ terraform destroy
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | = 2.64 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | = 2.64 |
+
 ## Modules
 
 | Name | Source | Version |

--- a/examples/panorama/README.md
+++ b/examples/panorama/README.md
@@ -22,6 +22,13 @@ $ terraform apply
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 2.42 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+
 ## Modules
 
 | Name | Source | Version |

--- a/examples/transit_vnet_common/README.md
+++ b/examples/transit_vnet_common/README.md
@@ -20,6 +20,13 @@ $ terraform apply
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | = 2.97 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | = 2.97 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+
 ## Modules
 
 | Name | Source | Version |

--- a/examples/transit_vnet_dedicated/README.md
+++ b/examples/transit_vnet_dedicated/README.md
@@ -21,6 +21,13 @@ terraform ouput -json password
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | = 2.64 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | = 2.64 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+
 ## Modules
 
 | Name | Source | Version |

--- a/examples/vmseries/README.md
+++ b/examples/vmseries/README.md
@@ -41,6 +41,13 @@ terraform destroy
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | = 2.64 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | = 2.64 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+
 ## Modules
 
 | Name | Source | Version |

--- a/examples/vmseries_scaleset/README.md
+++ b/examples/vmseries_scaleset/README.md
@@ -73,6 +73,13 @@ terraform destroy
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | = 2.64 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | = 2.64 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+
 ## Modules
 
 | Name | Source | Version |

--- a/examples/vnet/README.md
+++ b/examples/vnet/README.md
@@ -21,6 +21,12 @@ $ terraform apply
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29, < 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | = 2.64 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | = 2.64 |
+
 ## Modules
 
 | Name | Source | Version |

--- a/modules/appgw/README.md
+++ b/modules/appgw/README.md
@@ -55,6 +55,12 @@ module "appgw" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29, < 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.90 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 2.90 |
+
 ## Modules
 
 No modules.

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -59,6 +59,13 @@ resource "local_file" "this" {
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 2.42 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+
 ## Modules
 
 No modules.

--- a/modules/loadbalancer/README.md
+++ b/modules/loadbalancer/README.md
@@ -64,6 +64,12 @@ module "outbound_lb" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29, < 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.64 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 2.64 |
+
 ## Modules
 
 No modules.

--- a/modules/panorama/README.md
+++ b/modules/panorama/README.md
@@ -42,6 +42,12 @@ module "panorama" {
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.64 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 2.64 |
+
 ## Modules
 
 No modules.

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -55,6 +55,12 @@ If your Region doesn't, use an alternative mechanism of Availability Set, which 
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29, < 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.64 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 2.64 |
+
 ## Modules
 
 No modules.

--- a/modules/vmss/README.md
+++ b/modules/vmss/README.md
@@ -29,6 +29,12 @@ module "vmss" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29, < 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.26 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 2.26 |
+
 ## Modules
 
 No modules.

--- a/modules/vnet/README.md
+++ b/modules/vnet/README.md
@@ -35,6 +35,12 @@ module "vnet" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29, < 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.26 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 2.26 |
+
 ## Modules
 
 No modules.


### PR DESCRIPTION
## Description

Update READMEs to include changes generated by terraform-docs after enabling hcl lock file ignoring (https://github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules/pull/151).

## Motivation and Context

Those changes for some reason were not introduced together with the hook config change and can result in extra changes for non-related PRs.

## How Has This Been Tested?

Docs only change

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
