### PR TITLE
feat(ci): A new workflow to validate TF code against different TF versions

### DIFF
--- a/.github/actions/validate_tf/action.yml
+++ b/.github/actions/validate_tf/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: run validation for ${{ inputs.path }}
       run: |
         cd "$GITHUB_WORKSPACE"/${{ inputs.path }}
-        pwd
+        terraform -version
         terraform init -backend=false
         terraform validate
       shell: bash

--- a/.github/actions/validate_tf/action.yml
+++ b/.github/actions/validate_tf/action.yml
@@ -1,0 +1,23 @@
+name: 'validate TF'
+description: 'run all pre-req steps and the actual TF code validation'
+inputs:
+  tf_version:  # id of input
+    description: 'TF version used to validate code.'
+    required: true
+  path:
+    description: 'Path to code that will be validated.'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: setup Terraform
+      uses: hashicorp/setup-terraform@v2
+      with:
+        terraform_version: ${{ inputs.tf_version }}
+    - name: run validation for ${{ inputs.path }}
+      run: |
+        cd "$GITHUB_WORKSPACE"/${{ inputs.path }}
+        pwd
+        terraform init -backend=false
+        terraform validate
+      shell: bash

--- a/.github/workflows/tf_validate_ver.yml
+++ b/.github/workflows/tf_validate_ver.yml
@@ -1,0 +1,36 @@
+---
+name: Validate examples against variety of TF versions
+
+on:
+  workflow_dispatch:
+
+jobs: 
+  validate:
+    name: validate examples
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tf_version: 
+          - '0.15.0'
+          - '1.0.0'
+          - '1.2.0'
+
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v3
+      
+      - name: setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ matrix.tf_version }}
+
+      - name: run validation
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          for dir in $(find examples -type d -not \( -name ".?*" \) -maxdepth 1 -mindepth 1);
+          do
+            echo "Processing directory: $dir"
+            cd "$GITHUB_WORKSPACE/$dir"
+            terraform init -backend=false
+            terraform validate
+          done

--- a/.github/workflows/tf_validate_ver.yml
+++ b/.github/workflows/tf_validate_ver.yml
@@ -1,39 +1,73 @@
 ---
-name: Validate examples against variety of TF versions
+name: Validate examples and modules against variety of TF versions
 
 on:
-  push:
-    branches:
-      - tf_validate_ver
-  # workflow_dispatch:
+  # push:
+  #   branch:
+  #     - develop
+  workflow_dispatch:
+
+env:
+  # tf_versions needs to be a string of TF versions we would like to test against
+  # versions have to be space delimited
+  tf_versions: 0.15.0 1.0.0 1.2.0
 
 jobs: 
-  validate:
+  prerequisites:
+    name: get a list of modules to check
+    runs-on: ubuntu-latest
+    outputs:
+      modules: ${{ steps.preqs.outputs.modules }}
+      examples: ${{ steps.preqs.outputs.examples }}
+      tf_versions: ${{ steps.preqs.outputs.tf_versions }}
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v3
+      - name: set outputs
+        id: preqs
+        run: |
+          echo "::set-output name=modules::$(find modules -type d -not \( -name ".?*" \) -maxdepth 1 -mindepth 1 | jq -R -s -c 'split("\n")[:-1]')"
+          echo "::set-output name=examples::$(find examples -type d -not \( -name ".?*" \) -maxdepth 1 -mindepth 1 | jq -R -s -c 'split("\n")[:-1]')"
+          echo "::set-output name=tf_versions::$(echo ${tf_versions}| tr " " "\n" | jq -R -s -c 'split("\n")[:-1]')"
+
+  modules:
+    needs: [prerequisites]
+    name: validate modules
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tf_versions: ${{ fromJson(needs.prerequisites.outputs.tf_versions) }}
+        modules: ${{ fromJson(needs.prerequisites.outputs.modules) }}
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v3
+      - name: setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ matrix.tf_versions }}
+      - name: run modules validation
+        run: |
+          cd "$GITHUB_WORKSPACE/${{ matrix.modules }}"
+          terraform init -backend=false
+          terraform validate
+
+  examples:
+    needs: [prerequisites]
     name: validate examples
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tf_version: 
-          - '0.15.0'
-          - '1.0.0'
-          - '1.2.0'
-
+        tf_versions: ${{ fromJson(needs.prerequisites.outputs.tf_versions) }}
+        examples: ${{ fromJson(needs.prerequisites.outputs.examples) }}
     steps:
       - name: checkout code
         uses: actions/checkout@v3
-      
       - name: setup Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: ${{ matrix.tf_version }}
-
-      - name: run validation
+          terraform_version: ${{ matrix.tf_versions }}
+      - name: run examples validation
         run: |
-          cd "$GITHUB_WORKSPACE"
-          for dir in $(find examples -type d -not \( -name ".?*" \) -maxdepth 1 -mindepth 1);
-          do
-            echo "Processing directory: $dir"
-            cd "$GITHUB_WORKSPACE/$dir"
-            terraform init -backend=false
-            terraform validate
-          done
+          cd "$GITHUB_WORKSPACE/${{ matrix.examples }}"
+          terraform init -backend=false
+          terraform validate

--- a/.github/workflows/tf_validate_ver.yml
+++ b/.github/workflows/tf_validate_ver.yml
@@ -2,7 +2,10 @@
 name: Validate examples against variety of TF versions
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - tf_validate_ver
+  # workflow_dispatch:
 
 jobs: 
   validate:

--- a/.github/workflows/tf_validate_ver.yml
+++ b/.github/workflows/tf_validate_ver.yml
@@ -1,5 +1,6 @@
 ---
-name: Validate examples and modules against variety of TF versions
+name: TF Validate
+# description: Validate examples and modules against variety of TF versions
 
 on:
   workflow_dispatch:
@@ -7,11 +8,12 @@ on:
 env:
   # tf_versions needs to be a string of TF versions we would like to test against
   # versions have to be space delimited
-  tf_versions: 0.15.0 1.0.0 1.2.0
+  # when providing only major.minor version the latest patch level will be used
+  tf_versions: 0.15 1.0 1.1 1.2
 
 jobs: 
   prerequisites:
-    name: get a list of modules to check
+    name: gather prerequisites
     runs-on: ubuntu-latest
     outputs:
       modules: ${{ steps.preqs.outputs.modules }}
@@ -23,8 +25,8 @@ jobs:
       - name: set outputs
         id: preqs
         run: |
-          echo "::set-output name=modules::$(find modules -type d -not \( -name ".?*" \) -maxdepth 1 -mindepth 1 | jq -R -s -c 'split("\n")[:-1]')"
-          echo "::set-output name=examples::$(find examples -type d -not \( -name ".?*" \) -maxdepth 1 -mindepth 1 | jq -R -s -c 'split("\n")[:-1]')"
+          echo "::set-output name=modules::$(find modules -maxdepth 1 -mindepth 1 -type d -not \( -name ".?*" \) | jq -R -s -c 'split("\n")[:-1]')"
+          echo "::set-output name=examples::$(find examples -maxdepth 1 -mindepth 1 -type d -not \( -name ".?*" \) | jq -R -s -c 'split("\n")[:-1]')"
           echo "::set-output name=tf_versions::$(echo ${tf_versions}| tr " " "\n" | jq -R -s -c 'split("\n")[:-1]')"
 
   modules:

--- a/.github/workflows/tf_validate_ver.yml
+++ b/.github/workflows/tf_validate_ver.yml
@@ -2,9 +2,6 @@
 name: Validate examples and modules against variety of TF versions
 
 on:
-  # push:
-  #   branch:
-  #     - develop
   workflow_dispatch:
 
 env:
@@ -32,42 +29,33 @@ jobs:
 
   modules:
     needs: [prerequisites]
-    name: validate modules
     runs-on: ubuntu-latest
     strategy:
       matrix:
         tf_versions: ${{ fromJson(needs.prerequisites.outputs.tf_versions) }}
         modules: ${{ fromJson(needs.prerequisites.outputs.modules) }}
+    name: '${{ matrix.modules }}@${{ matrix.tf_versions }}'
     steps:
       - name: checkout code
         uses: actions/checkout@v3
-      - name: setup Terraform
-        uses: hashicorp/setup-terraform@v2
+      - name: run validation
+        uses: ./.github/actions/validate_tf
         with:
-          terraform_version: ${{ matrix.tf_versions }}
-      - name: run modules validation
-        run: |
-          cd "$GITHUB_WORKSPACE/${{ matrix.modules }}"
-          terraform init -backend=false
-          terraform validate
-
+          path: ${{ matrix.modules }}
+          tf_version: ${{ matrix.tf_versions }}
   examples:
     needs: [prerequisites]
-    name: validate examples
     runs-on: ubuntu-latest
     strategy:
       matrix:
         tf_versions: ${{ fromJson(needs.prerequisites.outputs.tf_versions) }}
         examples: ${{ fromJson(needs.prerequisites.outputs.examples) }}
+    name: '${{ matrix.examples }}@${{ matrix.tf_versions }}'
     steps:
       - name: checkout code
         uses: actions/checkout@v3
-      - name: setup Terraform
-        uses: hashicorp/setup-terraform@v2
+      - name: run validation
+        uses: ./.github/actions/validate_tf
         with:
-          terraform_version: ${{ matrix.tf_versions }}
-      - name: run examples validation
-        run: |
-          cd "$GITHUB_WORKSPACE/${{ matrix.examples }}"
-          terraform init -backend=false
-          terraform validate
+          path: ${{ matrix.examples }}
+          tf_version: ${{ matrix.tf_versions }}


### PR DESCRIPTION
## Description

A manually triggered workflow (for the moment) that runs `terraform validate` against all modules and examples. It does it for different TF versions. Currently these are: 0.15.0, 1.0.0, 1.2.0.

Code is run in threads, meaning that each module/example is tested against all TF versions at the same time. 

Since testing required commits to `develop` branch, development was done on a [fork repo, `develop` branch](https://github.com/FoSix/terraform-azurerm-vmseries-modules/actions/runs/2846100286). This PR is only the final code. 

## Motivation and Context

We need to make sure that while developing the code with the latest TF versions the code stays compatible with the declared range. Doing this manually is almost impossible. 

## How Has This Been Tested?

Workflow was run locally using `act` and on a forked repo (a commit to develop branch was required)

## Screenshots (if appropriate)

![Validate_examples_and_modules_against_variety_of_TF_versions_·_FoSix_terraform-azurerm-vmseries-modules_e6b6b05_-_Vivaldi](https://user-images.githubusercontent.com/42772730/184337239-051d3fe2-3282-4d55-a681-106d03ad8c45.png)


## Types of changes



- New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
