### PR TITLE
fix: add relaxed azure provider version requirements

### DIFF
--- a/examples/bootstrap/README.md
+++ b/examples/bootstrap/README.md
@@ -32,7 +32,6 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15, < 2.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
 
 ## Providers
 

--- a/examples/bootstrap/versions.tf
+++ b/examples/bootstrap/versions.tf
@@ -5,8 +5,7 @@ terraform {
       source = "hashicorp/azurerm"
     }
     random = {
-      source  = "hashicorp/random"
-      version = "~> 3.1"
+      source = "hashicorp/random"
     }
   }
 }

--- a/examples/panorama/README.md
+++ b/examples/panorama/README.md
@@ -19,15 +19,13 @@ $ terraform apply
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13, < 2.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.7.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.7.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 

--- a/examples/panorama/versions.tf
+++ b/examples/panorama/versions.tf
@@ -2,12 +2,10 @@ terraform {
   required_version = ">= 0.13, < 2.0"
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 3.7.0"
+      source = "hashicorp/azurerm"
     }
     random = {
-      source  = "hashicorp/random"
-      version = "~> 3.1"
+      source = "hashicorp/random"
     }
   }
 }

--- a/examples/transit_vnet_common/README.md
+++ b/examples/transit_vnet_common/README.md
@@ -17,15 +17,13 @@ $ terraform apply
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13, < 2.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | = 3.7.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | = 3.7.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
@@ -41,9 +39,9 @@ $ terraform apply
 
 | Name | Type |
 |------|------|
-| [azurerm_network_security_rule.mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/network_security_rule) | resource |
-| [azurerm_public_ip.public](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/public_ip) | resource |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/resource_group) | resource |
+| [azurerm_network_security_rule.mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
+| [azurerm_public_ip.public](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [random_password.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 
 ## Inputs

--- a/examples/transit_vnet_common/versions.tf
+++ b/examples/transit_vnet_common/versions.tf
@@ -2,12 +2,10 @@ terraform {
   required_version = ">= 0.13, < 2.0"
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "= 3.7.0"
+      source = "hashicorp/azurerm"
     }
     random = {
-      source  = "hashicorp/random"
-      version = "~> 3.1"
+      source = "hashicorp/random"
     }
   }
 }

--- a/examples/transit_vnet_dedicated/README.md
+++ b/examples/transit_vnet_dedicated/README.md
@@ -18,15 +18,13 @@ terraform ouput -json password
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13, < 2.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | = 3.7.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | = 3.7.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
@@ -44,9 +42,9 @@ terraform ouput -json password
 
 | Name | Type |
 |------|------|
-| [azurerm_network_security_rule.mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/network_security_rule) | resource |
-| [azurerm_public_ip.public](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/public_ip) | resource |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/resource_group) | resource |
+| [azurerm_network_security_rule.mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
+| [azurerm_public_ip.public](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [random_password.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 
 ## Inputs

--- a/examples/transit_vnet_dedicated/versions.tf
+++ b/examples/transit_vnet_dedicated/versions.tf
@@ -2,12 +2,10 @@ terraform {
   required_version = ">= 0.13, < 2.0"
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "= 3.7.0"
+      source = "hashicorp/azurerm"
     }
     random = {
-      source  = "hashicorp/random"
-      version = "~> 3.1"
+      source = "hashicorp/random"
     }
   }
 }

--- a/examples/vmseries/README.md
+++ b/examples/vmseries/README.md
@@ -38,15 +38,13 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29, < 2.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | = 3.7.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | = 3.7.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
@@ -60,7 +58,7 @@ terraform destroy
 
 | Name | Type |
 |------|------|
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/resource_group) | resource |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [random_password.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 
 ## Inputs

--- a/examples/vmseries/versions.tf
+++ b/examples/vmseries/versions.tf
@@ -2,12 +2,10 @@ terraform {
   required_version = ">= 0.12.29, < 2.0"
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "= 3.7.0"
+      source = "hashicorp/azurerm"
     }
     random = {
-      source  = "hashicorp/random"
-      version = "~> 3.1"
+      source = "hashicorp/random"
     }
   }
 }

--- a/examples/vmseries_scaleset/README.md
+++ b/examples/vmseries_scaleset/README.md
@@ -70,15 +70,13 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29, < 2.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | = 3.7.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | = 3.7.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
@@ -96,21 +94,21 @@ terraform destroy
 
 | Name | Type |
 |------|------|
-| [azurerm_nat_gateway.mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/nat_gateway) | resource |
-| [azurerm_nat_gateway.outbound](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/nat_gateway) | resource |
-| [azurerm_nat_gateway_public_ip_association.mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/nat_gateway_public_ip_association) | resource |
-| [azurerm_nat_gateway_public_ip_association.outbound](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/nat_gateway_public_ip_association) | resource |
-| [azurerm_network_security_rule.mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/network_security_rule) | resource |
-| [azurerm_public_ip.mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/public_ip) | resource |
-| [azurerm_public_ip.outbound](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/public_ip) | resource |
-| [azurerm_resource_group.inbound](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/resource_group) | resource |
-| [azurerm_resource_group.outbound](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/resource_group) | resource |
-| [azurerm_subnet_nat_gateway_association.mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/subnet_nat_gateway_association) | resource |
-| [azurerm_subnet_nat_gateway_association.outbound_private](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/subnet_nat_gateway_association) | resource |
-| [azurerm_subnet_nat_gateway_association.outbound_public](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/subnet_nat_gateway_association) | resource |
+| [azurerm_nat_gateway.mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway) | resource |
+| [azurerm_nat_gateway.outbound](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway) | resource |
+| [azurerm_nat_gateway_public_ip_association.mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway_public_ip_association) | resource |
+| [azurerm_nat_gateway_public_ip_association.outbound](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway_public_ip_association) | resource |
+| [azurerm_network_security_rule.mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
+| [azurerm_public_ip.mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
+| [azurerm_public_ip.outbound](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
+| [azurerm_resource_group.inbound](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_resource_group.outbound](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_subnet_nat_gateway_association.mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_nat_gateway_association) | resource |
+| [azurerm_subnet_nat_gateway_association.outbound_private](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_nat_gateway_association) | resource |
+| [azurerm_subnet_nat_gateway_association.outbound_public](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_nat_gateway_association) | resource |
 | [random_password.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
-| [azurerm_resource_group.inbound](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/data-sources/resource_group) | data source |
-| [azurerm_resource_group.outbound](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.inbound](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.outbound](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 

--- a/examples/vmseries_scaleset/versions.tf
+++ b/examples/vmseries_scaleset/versions.tf
@@ -2,12 +2,10 @@ terraform {
   required_version = ">= 0.12.29, < 2.0"
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "= 3.7.0"
+      source = "hashicorp/azurerm"
     }
     random = {
-      source  = "hashicorp/random"
-      version = "~> 3.1"
+      source = "hashicorp/random"
     }
   }
 }

--- a/examples/vnet/README.md
+++ b/examples/vnet/README.md
@@ -19,13 +19,12 @@ $ terraform apply
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29, < 2.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | = 3.7.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | = 3.7.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
 
 ## Modules
 
@@ -37,7 +36,7 @@ $ terraform apply
 
 | Name | Type |
 |------|------|
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.7.0/docs/resources/resource_group) | resource |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 
 ## Inputs
 

--- a/examples/vnet/versions.tf
+++ b/examples/vnet/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_version = ">= 0.12.29, < 2.0"
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "= 3.7.0"
+      source = "hashicorp/azurerm"
     }
   }
 }

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -58,14 +58,14 @@ resource "local_file" "this" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29, < 2.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.7.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.7 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.7.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.7 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.1 |
 
 ## Modules

--- a/modules/bootstrap/versions.tf
+++ b/modules/bootstrap/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.7.0"
+      version = "~> 3.7"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/loadbalancer/README.md
+++ b/modules/loadbalancer/README.md
@@ -62,13 +62,13 @@ module "outbound_lb" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15, < 2.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.7.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.7 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.7.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.7 |
 
 ## Modules
 

--- a/modules/loadbalancer/versions.tf
+++ b/modules/loadbalancer/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.7.0"
+      version = "~> 3.7"
     }
   }
 }

--- a/modules/panorama/README.md
+++ b/modules/panorama/README.md
@@ -39,14 +39,14 @@ module "panorama" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29, < 2.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.7.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.7 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.7.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.7 |
 
 ## Modules
 

--- a/modules/panorama/versions.tf
+++ b/modules/panorama/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.7.0"
+      version = "~> 3.7"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/virtual_machine/versions.tf
+++ b/modules/virtual_machine/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.7.0"
+      version = "~> 3.7"
     }
   }
 }

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -53,13 +53,13 @@ If your Region doesn't, use an alternative mechanism of Availability Set, which 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29, < 2.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.7.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.7 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.7.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.7 |
 
 ## Modules
 

--- a/modules/vmseries/versions.tf
+++ b/modules/vmseries/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.7.0"
+      version = "~> 3.7"
     }
   }
 }

--- a/modules/vmss/README.md
+++ b/modules/vmss/README.md
@@ -27,13 +27,13 @@ module "vmss" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29, < 2.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.7.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.7 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.7.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.7 |
 
 ## Modules
 

--- a/modules/vmss/versions.tf
+++ b/modules/vmss/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.7.0"
+      version = "~> 3.7"
     }
   }
 }

--- a/modules/vnet/README.md
+++ b/modules/vnet/README.md
@@ -33,13 +33,13 @@ module "vnet" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29, < 2.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.7.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.7 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.7.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.7 |
 
 ## Modules
 

--- a/modules/vnet/versions.tf
+++ b/modules/vnet/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.7.0"
+      version = "~> 3.7"
     }
   }
 }


### PR DESCRIPTION
## Description

The current version requirements for Azure were `~>3.7.0`. Even though `~>` was used, the version has patch value included which prevents using more recent 3.x provider versions.

Also the version requirements were removed from examples, this way we relay on minimum versions from modules. The example is only a glue-code and does not relay on the provider directly. 

## Motivation and Context

We're pinned to Azure provider version 3.7.0.

## How Has This Been Tested?

`terraform init` was run to check if a newer version then 3.7.0 will be used. 

## Screenshots (if appropriate)



## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)



## Checklist




- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
