### PR TITLE
fix: use Hashicorp random provider in ~> 3.4.3 version

### DIFF
--- a/examples/bootstrap/README.md
+++ b/examples/bootstrap/README.md
@@ -32,6 +32,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15, < 2.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.4.3 |
 
 ## Providers
 

--- a/examples/bootstrap/versions.tf
+++ b/examples/bootstrap/versions.tf
@@ -5,7 +5,8 @@ terraform {
       source = "hashicorp/azurerm"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 3.4.3"
     }
   }
 }

--- a/examples/panorama/README.md
+++ b/examples/panorama/README.md
@@ -19,13 +19,14 @@ $ terraform apply
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13, < 2.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.4.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.4.3 |
 
 ## Modules
 

--- a/examples/panorama/versions.tf
+++ b/examples/panorama/versions.tf
@@ -5,7 +5,8 @@ terraform {
       source = "hashicorp/azurerm"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 3.4.3"
     }
   }
 }

--- a/examples/transit_vnet_common/README.md
+++ b/examples/transit_vnet_common/README.md
@@ -17,13 +17,14 @@ $ terraform apply
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13, < 2.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.4.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.4.3 |
 
 ## Modules
 

--- a/examples/transit_vnet_common/versions.tf
+++ b/examples/transit_vnet_common/versions.tf
@@ -5,7 +5,8 @@ terraform {
       source = "hashicorp/azurerm"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 3.4.3"
     }
   }
 }

--- a/examples/transit_vnet_dedicated/README.md
+++ b/examples/transit_vnet_dedicated/README.md
@@ -18,13 +18,14 @@ terraform ouput -json password
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13, < 2.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.4.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.4.3 |
 
 ## Modules
 

--- a/examples/transit_vnet_dedicated/versions.tf
+++ b/examples/transit_vnet_dedicated/versions.tf
@@ -5,7 +5,8 @@ terraform {
       source = "hashicorp/azurerm"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 3.4.3"
     }
   }
 }

--- a/examples/vmseries/README.md
+++ b/examples/vmseries/README.md
@@ -38,13 +38,14 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29, < 2.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.4.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.4.3 |
 
 ## Modules
 

--- a/examples/vmseries/versions.tf
+++ b/examples/vmseries/versions.tf
@@ -5,7 +5,8 @@ terraform {
       source = "hashicorp/azurerm"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 3.4.3"
     }
   }
 }

--- a/examples/vmseries_scaleset/README.md
+++ b/examples/vmseries_scaleset/README.md
@@ -70,13 +70,14 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29, < 2.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.4.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.4.3 |
 
 ## Modules
 

--- a/examples/vmseries_scaleset/versions.tf
+++ b/examples/vmseries_scaleset/versions.tf
@@ -5,7 +5,8 @@ terraform {
       source = "hashicorp/azurerm"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 3.4.3"
     }
   }
 }

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -59,14 +59,14 @@ resource "local_file" "this" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29, < 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.7 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.4.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.7 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.4.3 |
 
 ## Modules
 

--- a/modules/bootstrap/versions.tf
+++ b/modules/bootstrap/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1"
+      version = "~> 3.4.3"
     }
   }
 }

--- a/modules/panorama/README.md
+++ b/modules/panorama/README.md
@@ -40,7 +40,7 @@ module "panorama" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29, < 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.7 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.4.3 |
 
 ## Providers
 

--- a/modules/panorama/versions.tf
+++ b/modules/panorama/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1"
+      version = "~> 3.4.3"
     }
   }
 }


### PR DESCRIPTION
## Description

In examples and modules there were changes in version of ``random`` provider. On M1 based machines there was an error, if provider in version lower than ``3.1.0`` was used, because there is no such release for ``darwin/arm64``.

## Motivation and Context

PR resolves issue #157.

## How Has This Been Tested?

Changes were tested on local machine by deploying ``examples/vmseries``.

## Screenshots (if appropriate)

While using older version of ``random`` provider on M1 based machine, there was an error:

```
│ Error: Failed to query available provider packages
│
│ Could not retrieve the list of available versions for provider hashicorp/random: no available releases match the given constraints < 3.0.0, ~> 3.1
```

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
