### PR TITLE
fix(module/vmseries,module/vmss): removed validation for user data bootstrapping

### DIFF
--- a/modules/vmseries/variables.tf
+++ b/modules/vmseries/variables.tf
@@ -200,16 +200,6 @@ variable "bootstrap_options" {
   EOF
   default     = ""
   type        = string
-  validation {
-    condition = alltrue([
-      for v in var.bootstrap_options == "" ? [] : split(";", var.bootstrap_options) :
-      contains(
-        ["storage-account", "access-key", "file-share", "share-directory", "type", "ip-address", "default-gateway", "netmask", "ipv6-address", "ipv6-default-gateway", "hostname", "panorama-server", "panorama-server-2", "tplname", "dgname", "dns-primary", "dns-secondary", "vm-auth-key", "op-command-modes", "op-cmd-dpdk-pkt-io", "plugin-op-commands", "dhcp-send-hostname", "dhcp-send-client-id", "dhcp-accept-server-hostname", "dhcp-accept-server-domain", "auth-key", "vm-series-auto-registration-pin-value", "vm-series-auto-registration-pin-id"],
-        split("=", v)[0]
-      )
-    ])
-    error_message = "Error in validating bootstrap_options, for details see variable description."
-  }
 }
 
 variable "diagnostics_storage_uri" {

--- a/modules/vmss/variables.tf
+++ b/modules/vmss/variables.tf
@@ -393,16 +393,6 @@ variable "bootstrap_options" {
   EOF
   default     = ""
   type        = string
-  validation {
-    condition = alltrue([
-      for v in var.bootstrap_options == "" ? [] : split(";", var.bootstrap_options) :
-      contains(
-        ["storage-account", "access-key", "file-share", "share-directory", "type", "ip-address", "default-gateway", "netmask", "ipv6-address", "ipv6-default-gateway", "hostname", "panorama-server", "panorama-server-2", "tplname", "dgname", "dns-primary", "dns-secondary", "vm-auth-key", "op-command-modes", "op-cmd-dpdk-pkt-io", "plugin-op-commands", "dhcp-send-hostname", "dhcp-send-client-id", "dhcp-accept-server-hostname", "dhcp-accept-server-domain", "auth-key", "vm-series-auto-registration-pin-value", "vm-series-auto-registration-pin-id"],
-        split("=", v)[0]
-      )
-    ])
-    error_message = "Error in validating bootstrap_options, for details see variable description."
-  }
 }
 
 variable "diagnostics_storage_uri" {


### PR DESCRIPTION
## Description

Removed validation block for user data bootstrap options in both the vmseries and vmss modules.

## Motivation and Context

The bootstrap options are not fully documented. Having this functionality limits flexibility on the user data bootstrapping usage. And it does not guarantee that the firewall will be correctly configured - the property name can be OK, but it's content not. 

## How Has This Been Tested?


## Screenshots (if appropriate)


## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
