### PR TITLE
fix: adding sensitive property to password and bootstrap_option variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           # Semantic version range syntax (like 3.x) or the exact Python version
-          python-version: '3.9.4'
+          python-version: '3.10'
 
       - name: Run pre-commit framework as the developer should run it
         run: sudo ./scripts/install.sh && sudo ./scripts/run.sh

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ This repository has the following directory structure:
   `modules` directory. \
   Notice, **this code should NOT be used directly in production**. It might contain examples of sensitive data that normally should not be kept in a repository.
 
+## Security
+
+Please keep in mind that modules hosted in this repository require sensitive data to work, like: passwords, firewall bootstrap options, etc. We do not provide a mechanism to safely store this information. It's up to you to make sure this data is safely kept.
+
+Examples provided here are a form of documentation - they should help you understand how to use the modules. They were not written with security in mind. They are here to demonstrate how to utilize code available in this repository and sometimes it's not possible to do it w/o providing variables or data that normally (in production) would not be kept in a VCS.
+
+So before you use this code for something different than training please keep in mind to follow all Terraform and your organization's security best practices.
+
 ## Compatibility
 
 The compatibility with Terraform is defined individually per each module. In general, expect the earliest compatible

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ This repository has the following directory structure:
 
 * `modules` - this directory contains several standalone, reusable, production-grade Terraform modules. Each module is individually documented.
 * `examples` - this directory shows examples of different ways to combine the modules contained in the
-  `modules` directory.
+  `modules` directory. \
+  Notice, **this code should NOT be used directly in production**. It might contain examples of sensitive data that normally should not be kept in a repository.
 
 ## Compatibility
 

--- a/examples/bootstrap/README.md
+++ b/examples/bootstrap/README.md
@@ -10,6 +10,10 @@ The following resources will be deployed when using the provided example:
 * 1 [Storage Account](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-overview)
 * 2 [File Shares](https://docs.microsoft.com/en-us/azure/storage/files/storage-files-introduction#:~:text=Azure%20Files%20offers%20fully%20managed,cloud%20or%20on%2Dpremises%20deployments).
 
+## NOTICE
+
+This example contains some files that can contain sensitive data, namely `authcodes.sample` and `init-cfg.sample.txt`. Keep in mind that these files are here only as an example. Normally one should avoid placing them in a repository.
+
 ## Usage
 
 Create a `terraform.tfvars` file and copy the content of `example.tfvars` into it, adjust the variables (in particular the `storage_account_name` should be unique).

--- a/examples/transit_vnet_common/README.md
+++ b/examples/transit_vnet_common/README.md
@@ -2,6 +2,10 @@
 
 This folder shows an example of Terraform code that helps to deploy a [Transit VNet design model](https://www.paloaltonetworks.com/resources/guides/azure-transit-vnet-deployment-guide-common-firewall-option) (common firewall option) with a VM-Series firewall on Microsoft Azure.
 
+## NOTICE
+
+This example contains some files that can contain sensitive data, namely `authcodes.sample` and `init-cfg.sample.txt`. Keep in mind that these files are here only as an example. Normally one should avoid placing them in a repository.
+
 ## Usage
 
 Create a `terraform.tfvars` file and copy the content of `example.tfvars` into it, adjust if needed.

--- a/examples/transit_vnet_common/variables.tf
+++ b/examples/transit_vnet_common/variables.tf
@@ -26,6 +26,7 @@ variable "password" {
   description = "Initial administrative password to use for all systems. Set to null for an auto-generated password."
   default     = null
   type        = string
+  sensitive   = true
 }
 
 variable "vmseries" {

--- a/examples/transit_vnet_dedicated/README.md
+++ b/examples/transit_vnet_dedicated/README.md
@@ -2,6 +2,10 @@
 
 This folder shows an example of Terraform code that helps to deploy a [Transit VNet design model](https://www.paloaltonetworks.com/resources/guides/azure-transit-vnet-deployment-guide) with dedicated VM-Series firewalls on Microsoft Azure.
 
+## NOTICE
+
+This example contains some files that can contain sensitive data, namely `authcodes.sample` and `init-cfg.sample.txt`. Keep in mind that these files are here only as an example. Normally one should avoid placing them in a repository.
+
 ## Usage
 
 Create a `terraform.tfvars` file and copy the content of `example.tfvars` into it, adjust if needed.

--- a/examples/transit_vnet_dedicated/variables.tf
+++ b/examples/transit_vnet_dedicated/variables.tf
@@ -26,6 +26,7 @@ variable "password" {
   description = "Initial administrative password to use for all systems. Set to null for an auto-generated password."
   default     = null
   type        = string
+  sensitive   = true
 }
 
 variable "inbound_vmseries" {

--- a/examples/vmseries/README.md
+++ b/examples/vmseries/README.md
@@ -6,6 +6,10 @@ oneself with terraform, as well as a bed for creating a custom pan-os image.
 
 To see a full VM-Series module usage, see the example from the directory [../transit_vnet_common](../transit_vnet_common). It deploys one of the VM-Series Reference Architectures in its entirety, including load balancing.
 
+## NOTICE
+
+This example contains some files that can contain sensitive data, namely `authcodes.sample` and `init-cfg.sample.txt`. Keep in mind that these files are here only as an example. Normally one should avoid placing them in a repository.
+
 ## Usage
 
 Create a `terraform.tfvars` file and copy the content of `example.tfvars` into it, adjust if needed.

--- a/examples/vmseries_scaleset/README.md
+++ b/examples/vmseries_scaleset/README.md
@@ -9,6 +9,10 @@ This is not a complete autoscaling solution, the missing part is de-licensing, i
 - Panorama's plugin `azure` v2.0.3. (The v3 is incompatible.)
 - Panorama's plugin `sw_fw_license` v1. (See the [documentation](https://docs-new.paloaltonetworks.com/vm-series/10-1/vm-series-deployment/license-the-vm-series-firewall/use-panorama-based-software-firewall-license-management.html).)
 
+## NOTICE
+
+This example contains some files that can contain sensitive data, namely `authcodes.sample` and `init-cfg.sample.txt`. Keep in mind that these files are here only as an example. Normally one should avoid placing them in a repository.
+
 ## Usage
 
 1. Create a `terraform.tfvars` file and copy the content of `example.tfvars` into it, adjust if needed.

--- a/examples/vmseries_scaleset/variables.tf
+++ b/examples/vmseries_scaleset/variables.tf
@@ -42,6 +42,7 @@ variable "password" {
   description = "Initial administrative password to use for all systems. Set to null for an auto-generated password."
   default     = null
   type        = string
+  sensitive   = true
 }
 
 variable "storage_account_name" {

--- a/modules/panorama/variables.tf
+++ b/modules/panorama/variables.tf
@@ -57,6 +57,7 @@ variable "password" {
   description = "Initial administrative password to use for Panorama. If not defined the `ssh_key` variable must be specified. Mind the [Azure-imposed restrictions](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-password-requirements-when-creating-a-vm)."
   default     = null
   type        = string
+  sensitive   = true
 }
 
 variable "ssh_keys" {

--- a/modules/virtual_machine/variables.tf
+++ b/modules/virtual_machine/variables.tf
@@ -97,6 +97,7 @@ variable "username" {
 variable "password" {
   description = "Initial administrative password to use for the virtual machine. Mind the [Azure-imposed restrictions](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-password-requirements-when-creating-a-vm)."
   type        = string
+  sensitive   = true
 }
 
 variable "managed_disk_type" {

--- a/modules/vmseries/variables.tf
+++ b/modules/vmseries/variables.tf
@@ -89,6 +89,7 @@ variable "password" {
   description = "Initial administrative password to use for VM-Series. If not defined the `ssh_key` variable must be specified. Mind the [Azure-imposed restrictions](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-password-requirements-when-creating-a-vm)."
   default     = null
   type        = string
+  sensitive   = true
 }
 
 variable "ssh_keys" {
@@ -200,6 +201,7 @@ variable "bootstrap_options" {
   EOF
   default     = ""
   type        = string
+  sensitive   = true
 }
 
 variable "diagnostics_storage_uri" {

--- a/modules/vmss/variables.tf
+++ b/modules/vmss/variables.tf
@@ -69,6 +69,7 @@ variable "username" {
 variable "password" {
   description = "Initial administrative password to use for VM-Series."
   type        = string
+  sensitive   = true
 }
 
 variable "disable_password_authentication" {
@@ -393,6 +394,7 @@ variable "bootstrap_options" {
   EOF
   default     = ""
   type        = string
+  sensitive   = true
 }
 
 variable "diagnostics_storage_uri" {


### PR DESCRIPTION
## Description

Adding `sensitive` flag to variables that will hold sensitive data, like passwords or user data bootstrap options.

Additional comments were added to READMEs to emphasise that example hosted in this repository might contain sensitive data and should not be used in this form in production. 


## Motivation and Context

Encouraged by #205 

## How Has This Been Tested?

an example was run with the use of `sensitive` flag to verify that sensitive information was deducted from the CLI output

## Screenshots (if appropriate)

![lpawlega_M-C02FG0EKML87___Git_public_code_terraform-azurerm-vmseries-modules_examples_vmseries](https://user-images.githubusercontent.com/42772730/204505186-f05aa05b-6b38-43be-8520-e83ae0475217.png)


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
