### PR TITLE
feat(module/vmss): fix update deprecated vmss properties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.15.0
+          terraform_version: '1.0.0'
       - name: terraform validate
         run: |
           cd "$GITHUB_WORKSPACE"
@@ -57,10 +57,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: '3.10'
       - name: Test with Checkov
         id: checkov
         uses: bridgecrewio/checkov-action@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           # Semantic version range syntax (like 3.x) or the exact Python version
-          python-version: '3.9.4'
+          python-version: '3.10'
 
       - name: Run pre-commit framework as the developer should run it
         run: sudo ./scripts/install.sh && sudo ./scripts/run.sh

--- a/makefile
+++ b/makefile
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+TFPLAN=gh_ci.tfplan
+
+case $1 in
+  init)
+    echo "::  INITIALIZING TERRAFORM  ::"
+    terraform init | nl -bn
+    echo
+    ;;
+
+  validate)
+    echo "::  INITIALIZING TERRAFORM  ::"
+    terraform init -backend=false | nl -bn
+    echo
+    echo "::  VALIDATING CODE  ::"
+    terraform validate | nl -bn
+    echo
+    ;;
+
+  plan)
+    echo "::  PLANNING INFRASTRUCTURE  ::"
+    TF_PARAMS=${@: 2}
+    terraform plan ${TF_PARAMS} | nl -bn
+    echo
+    ;;
+
+  plan_file)
+    echo "::  CREATING INFRASTRUCTURE PLAN FILE  ::"
+    TF_PARAMS=${@: 2}
+    terraform plan ${TF_PARAMS} -out ${TFPLAN} | nl -bn
+    echo
+    ;;
+
+  apply_file)
+    echo "::  APPLYING INFRASTRUCTURE PLAN FILE  ::"
+    if [ -f "${TFPLAN}" ]; then
+      terraform apply ${TFPLAN} | nl -bn
+    else
+      echo "No TFPLAN file."
+      exit 1
+    fi
+    echo
+    ;;
+
+  indepotency)
+    echo "::  TESTING INDEPOTENCY  ::"
+    TF_PARAMS=${@: 2}
+    terraform plan -detailed-exitcode ${TF_PARAMS} | nl -bn
+    echo
+    ;;
+
+  destroy)
+    echo "::  DESTROYING INFRASTRUCTURE  ::"
+    TF_PARAMS=${@: 2}
+    for G in ${TF_PARAMS[@]}; do az group delete -g "$G" -y --no-wait | nl -bn; done
+    echo
+
+    echo "::  REMOVING INFRASTRUCTURE PLAN FILE  ::"
+    if [ -f "${TFPLAN}" ]; then rm ${TFPLAN} | nl -bn; fi
+    echo
+    ;;
+
+esac

--- a/modules/vmss/README.md
+++ b/modules/vmss/README.md
@@ -27,13 +27,13 @@ module "vmss" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29, < 2.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.7 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.21 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.7 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.21 |
 
 ## Modules
 
@@ -96,6 +96,7 @@ No modules.
 | <a name="input_public_backend_pool_id"></a> [public\_backend\_pool\_id](#input\_public\_backend\_pool\_id) | Identifier of the load balancer backend pool to associate with the public interface of each VM-Series firewall. | `string` | `null` | no |
 | <a name="input_public_pip_domain_name_label"></a> [public\_pip\_domain\_name\_label](#input\_public\_pip\_domain\_name\_label) | n/a | `string` | `null` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the existing resource group where to place the resources created. | `string` | n/a | yes |
+| <a name="input_scale_in_force_deletion"></a> [scale\_in\_force\_deletion](#input\_scale\_in\_force\_deletion) | When set to `true` will force delete machines selected for removal by the `scale_in_policy`. | `bool` | `false` | no |
 | <a name="input_scale_in_policy"></a> [scale\_in\_policy](#input\_scale\_in\_policy) | Which virtual machines are chosen for removal when a Virtual Machine Scale Set is scaled in. Either:<br><br>- `Default`, which, baring the availability zone usage and fault domain usage, deletes VM with the highest-numbered instance id,<br>- `NewestVM`, which, baring the availability zone usage, deletes VM with the newest creation time,<br>- `OldestVM`, which, baring the availability zone usage, deletes VM with the oldest creation time. | `string` | `null` | no |
 | <a name="input_scalein_cooldown_minutes"></a> [scalein\_cooldown\_minutes](#input\_scalein\_cooldown\_minutes) | Azure only considers deleting a VM after this number of minutes has passed since the last VM scaling action. Should be higher or equal to `scalein_window_minutes`. Must be between 1 and 10080 minutes. | `number` | `2880` | no |
 | <a name="input_scalein_statistic"></a> [scalein\_statistic](#input\_scalein\_statistic) | Aggregation to use within each minute (the time grain) for metrics coming from different virtual machines. Possible values are Average, Min and Max. | `string` | `"Max"` | no |

--- a/modules/vmss/main.tf
+++ b/modules/vmss/main.tf
@@ -9,7 +9,6 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
   overprovision                   = var.overprovision
   platform_fault_domain_count     = var.platform_fault_domain_count
   proximity_placement_group_id    = var.proximity_placement_group_id
-  scale_in_policy                 = var.scale_in_policy
   single_placement_group          = var.single_placement_group
   instances                       = var.autoscale_count_default
   computer_name_prefix            = null
@@ -56,6 +55,11 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
   upgrade_mode = "Manual"
 
   custom_data = base64encode(var.bootstrap_options)
+
+  scale_in {
+    rule                   = var.scale_in_policy
+    force_deletion_enabled = var.scale_in_force_deletion
+  }
 
   network_interface {
     name                          = "${var.name_prefix}${var.name_mgmt_nic_profile}"

--- a/modules/vmss/variables.tf
+++ b/modules/vmss/variables.tf
@@ -113,6 +113,12 @@ variable "scale_in_policy" {
   type        = string
 }
 
+variable "scale_in_force_deletion" {
+  description = "When set to `true` will force delete machines selected for removal by the `scale_in_policy`."
+  default     = false
+  type        = bool
+}
+
 variable "single_placement_group" {
   description = "See the [provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine_scale_set)."
   default     = null

--- a/modules/vmss/versions.tf
+++ b/modules/vmss/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.7"
+      version = "~> 3.21"
     }
   }
 }


### PR DESCRIPTION
## Description

Replace the `scale_in_policy` property with `scale_in` block introduced in version `3.21` of the Azure Terraform Provider.

## Motivation and Context

The `scale_in_policy` property is obsolete and will be removed in provider version `4.x`.

## How Has This Been Tested?

A VMSS example was deployed to make sure that the interface of the `vmss` module did not change.

## Screenshots (if appropriate)



## Types of changes

- New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
