### PR TITLE
feat(module/natgw): introduce NAT GW module

### DIFF
--- a/modules/natgw/README.md
+++ b/modules/natgw/README.md
@@ -2,7 +2,9 @@
 
 ## Purpose
 
-Terraform module used to deploy Azure NAT Gateway. For limitations and zone-resiliency considerations please refer to [Microsoft documentation](https://learn.microsoft.com/en-us/azure/virtual-network/nat-gateway/nat-overview)
+Terraform module used to deploy Azure NAT Gateway. For limitations and zone-resiliency considerations please refer to [Microsoft documentation](https://learn.microsoft.com/en-us/azure/virtual-network/nat-gateway/nat-overview).
+
+This module can be used to either create a new NAT Gateway or to connect an existing one with subnets deployed using (for example) the [VNET module](../vnet/README.md).
 
 ## Usage
 

--- a/modules/natgw/README.md
+++ b/modules/natgw/README.md
@@ -1,0 +1,82 @@
+# NAT Gateway module
+
+## Purpose
+
+Terraform module used to deploy Azure NAT Gateway. For limitations and zone-resiliency considerations please refer to [Microsoft documentation](https://learn.microsoft.com/en-us/azure/virtual-network/nat-gateway/nat-overview)
+
+## Usage
+
+To deploy this resource in it's minimum configuration following code snippet can be used (assuming that the VNET module is used to deploy VNET and Subnets):
+
+```terraform
+module "natgw" {
+  source = "../modules/natgw"
+
+  name                = "NATGW_name"
+  resource_group_name = "resource_group_name"
+  location            = "region_name"
+  subnet_ids          = { "a_subnet_name" = module.vnet.subnet_ids["a_subnet_name"] }
+}
+```
+
+This will create a NAT Gateway in with a single Public IP in a zone chosen by Azure.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0, < 2.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.25 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.25 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_nat_gateway.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway) | resource |
+| [azurerm_nat_gateway_public_ip_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway_public_ip_association) | resource |
+| [azurerm_nat_gateway_public_ip_prefix_association.nat_ips](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway_public_ip_prefix_association) | resource |
+| [azurerm_public_ip.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
+| [azurerm_public_ip_prefix.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip_prefix) | resource |
+| [azurerm_subnet_nat_gateway_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_nat_gateway_association) | resource |
+| [azurerm_nat_gateway.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/nat_gateway) | data source |
+| [azurerm_public_ip.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip) | data source |
+| [azurerm_public_ip_prefix.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip_prefix) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_create_natgw"></a> [create\_natgw](#input\_create\_natgw) | Triggers creation of a NAT Gateway when set to `true`.<br><br>Set it to `false` to source an existing resource. In this 'mode' the module will only bind an existing NAT Gateway to specified subnets. | `bool` | `true` | no |
+| <a name="input_create_pip"></a> [create\_pip](#input\_create\_pip) | Set `true` to create a Public IP resource that will be connected to newly created NAT Gateway. Not used when NAT Gateway is only sourced.<br><br>Setting this property to `false` has two meanings:<br>* when `existing_pip_name` is `null` simply no Public IP will be created<br>* when `existing_pip_name` is set to a name of an exiting Public IP resource it will be sourced and associated to this NAT Gateway. | `bool` | `true` | no |
+| <a name="input_create_pip_prefix"></a> [create\_pip\_prefix](#input\_create\_pip\_prefix) | Set `true` to create a Public IP Prefix resource that will be connected to newly created NAT Gateway. Not used when NAT Gateway is only sourced.<br><br>Setting this property to `false` has two meanings:<br>* when `existing_pip_prefix_name` is `null` simply no Public IP Prefix will be created<br>* when `existing_pip_prefix_name` is set to a name of an exiting Public IP Prefix resource it will be sourced and associated to this NAT Gateway. | `bool` | `false` | no |
+| <a name="input_existing_pip_name"></a> [existing\_pip\_name](#input\_existing\_pip\_name) | Name of an existing Public IP resource to associate with the NAT Gateway. Only for newly created resources. | `string` | `null` | no |
+| <a name="input_existing_pip_prefix_name"></a> [existing\_pip\_prefix\_name](#input\_existing\_pip\_prefix\_name) | Name of an existing Public IP Prefix resource to associate with the NAT Gateway. Only for newly created resources. | `string` | `null` | no |
+| <a name="input_existing_pip_prefix_resource_group_name"></a> [existing\_pip\_prefix\_resource\_group\_name](#input\_existing\_pip\_prefix\_resource\_group\_name) | Name of a resource group hosting the Public IP Prefix resource specified in `existing_pip_name`. When omitted Resource Group specified in `resource_group_name` will be used. | `string` | `null` | no |
+| <a name="input_existing_pip_resource_group_name"></a> [existing\_pip\_resource\_group\_name](#input\_existing\_pip\_resource\_group\_name) | Name of a resource group hosting the Public IP resource specified in `existing_pip_name`. When omitted Resource Group specified in `resource_group_name` will be used. | `string` | `null` | no |
+| <a name="input_idle_timeout"></a> [idle\_timeout](#input\_idle\_timeout) | Connection IDLE timeout in minutes. Only for newly created resources. | `number` | `null` | no |
+| <a name="input_location"></a> [location](#input\_location) | Azure region. Only for newly created resources. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of a NAT Gateway. | `string` | n/a | yes |
+| <a name="input_pip_prefix_length"></a> [pip\_prefix\_length](#input\_pip\_prefix\_length) | Number of bits of the Public IP Prefix. This basically specifies how many IP addresses are reserved. Azure default is `/28`.<br><br>This value can be between `0` and `31` but can be limited by limits set on Subscription level. | `number` | `null` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of a Resource Group hosting the NAT Gateway (either the existing one or the one that will be created). | `string` | n/a | yes |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A map of subnet IDs what will be bound with this NAT Gateway. Value is the subnet ID, key value does not matter but should be unique, typically it can be a subnet name. | `map(string)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags that will be assigned to resources created by this module. Only for newly created resources. | `map(string)` | `{}` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | Controls if the NAT Gateway will be bound to a specific zone or not. This is a string with the zone number or `null`. Only for newly created resources.<br><br>NAT Gateway is not zone-redundant. It is a zonal resource. It means that it's always deployed in a zone. It's up to the user to decide if a zone will be specified during resource deployment or if Azure will take that decision for the user. <br>Keep in mind that regardless of the fact that NAT Gateway is placed in a specific zone it can serve traffic for resources in all zones. But if that zone becomes unavailable resources in other zones will loose internet connectivity. <br><br>For design considerations, limitation and examples of zone-resiliency architecture please refer to [Microsoft documentation](https://learn.microsoft.com/en-us/azure/virtual-network/nat-gateway/nat-availability-zones). | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_natgw_pip"></a> [natgw\_pip](#output\_natgw\_pip) | n/a |
+| <a name="output_natgw_pip_prefix"></a> [natgw\_pip\_prefix](#output\_natgw\_pip\_prefix) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/natgw/main.tf
+++ b/modules/natgw/main.tf
@@ -1,0 +1,96 @@
+resource "azurerm_public_ip" "this" {
+  count = (var.create_natgw && var.create_pip) ? 1 : 0
+
+  name                = "${var.name}-pip"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  zones               = var.zone != null ? [var.zone] : null
+
+  tags = var.tags
+}
+
+data "azurerm_public_ip" "this" {
+  count = (var.create_natgw && !var.create_pip && var.existing_pip_name != null) ? 1 : 0
+
+  name                = var.existing_pip_name
+  resource_group_name = var.existing_pip_resource_group_name == null ? var.resource_group_name : var.existing_pip_resource_group_name
+}
+
+resource "azurerm_public_ip_prefix" "this" {
+  count = (var.create_natgw && var.create_pip_prefix) ? 1 : 0
+
+  name                = "${var.name}-pip-prefix"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  ip_version          = "IPv4"
+  prefix_length       = var.pip_prefix_length
+  sku                 = "Standard"
+  zones               = var.zone != null ? [var.zone] : null
+
+  tags = var.tags
+}
+
+data "azurerm_public_ip_prefix" "this" {
+  count = (var.create_natgw && !var.create_pip_prefix && var.existing_pip_prefix_name != null) ? 1 : 0
+
+  name                = var.existing_pip_prefix_name
+  resource_group_name = var.existing_pip_prefix_resource_group_name == null ? var.resource_group_name : var.existing_pip_prefix_resource_group_name
+}
+
+resource "azurerm_nat_gateway" "this" {
+  count = var.create_natgw ? 1 : 0
+
+  name                    = var.name
+  resource_group_name     = var.resource_group_name
+  location                = var.location
+  sku_name                = "Standard"
+  idle_timeout_in_minutes = var.idle_timeout
+  zones                   = var.zone != null ? [var.zone] : null
+
+  tags = var.tags
+}
+
+data "azurerm_nat_gateway" "this" {
+  count = var.create_natgw ? 0 : 1
+
+  name                = var.name
+  resource_group_name = var.resource_group_name
+}
+
+
+
+
+locals {
+  natgw_id = var.create_natgw ? azurerm_nat_gateway.this[0].id : data.azurerm_nat_gateway.this[0].id
+
+  pip = var.create_natgw ? (
+    var.create_pip ? azurerm_public_ip.this[0] : try(data.azurerm_public_ip.this[0], null)
+  ) : null
+
+  pip_prefix = var.create_natgw ? (
+    var.create_pip_prefix ? azurerm_public_ip_prefix.this[0] : try(data.azurerm_public_ip_prefix.this[0], null)
+  ) : null
+}
+
+resource "azurerm_nat_gateway_public_ip_association" "this" {
+  count = var.create_natgw && local.pip != null ? 1 : 0
+
+  nat_gateway_id       = local.natgw_id
+  public_ip_address_id = local.pip.id
+}
+
+resource "azurerm_nat_gateway_public_ip_prefix_association" "nat_ips" {
+  count = var.create_natgw && local.pip_prefix != null ? 1 : 0
+
+  nat_gateway_id      = local.natgw_id
+  public_ip_prefix_id = local.pip_prefix.id
+}
+
+resource "azurerm_subnet_nat_gateway_association" "this" {
+  for_each = var.subnet_ids
+
+  nat_gateway_id = local.natgw_id
+  subnet_id      = each.value
+}

--- a/modules/natgw/main.tf
+++ b/modules/natgw/main.tf
@@ -36,7 +36,7 @@ data "azurerm_public_ip_prefix" "this" {
   count = (var.create_natgw && !var.create_pip_prefix && var.existing_pip_prefix_name != null) ? 1 : 0
 
   name                = var.existing_pip_prefix_name
-  resource_group_name = var.existing_pip_prefix_resource_group_name == null ? var.resource_group_name : var.existing_pip_prefix_resource_group_name
+  resource_group_name = coalesce(var.existing_pip_prefix_resource_group_name, var.resource_group_name)
 }
 
 resource "azurerm_nat_gateway" "this" {
@@ -58,8 +58,6 @@ data "azurerm_nat_gateway" "this" {
   name                = var.name
   resource_group_name = var.resource_group_name
 }
-
-
 
 
 locals {

--- a/modules/natgw/outputs.tf
+++ b/modules/natgw/outputs.tf
@@ -1,0 +1,7 @@
+output "natgw_pip" {
+  value = try(local.pip.ip_address, null)
+}
+
+output "natgw_pip_prefix" {
+  value = try(local.pip_prefix.ip_prefix, null)
+}

--- a/modules/natgw/variables.tf
+++ b/modules/natgw/variables.tf
@@ -1,0 +1,112 @@
+variable "name" {
+  description = "Name of a NAT Gateway."
+  type        = string
+}
+
+variable "create_natgw" {
+  description = <<-EOF
+  Triggers creation of a NAT Gateway when set to `true`.
+  
+  Set it to `false` to source an existing resource. In this 'mode' the module will only bind an existing NAT Gateway to specified subnets.
+  EOF
+  default     = true
+  type        = bool
+}
+
+variable "resource_group_name" {
+  description = "Name of a Resource Group hosting the NAT Gateway (either the existing one or the one that will be created)."
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region. Only for newly created resources."
+  type        = string
+}
+
+variable "tags" {
+  description = "A map of tags that will be assigned to resources created by this module. Only for newly created resources."
+  default     = {}
+  type        = map(string)
+}
+
+variable "zone" {
+  description = <<-EOF
+  Controls if the NAT Gateway will be bound to a specific zone or not. This is a string with the zone number or `null`. Only for newly created resources.
+
+  NAT Gateway is not zone-redundant. It is a zonal resource. It means that it's always deployed in a zone. It's up to the user to decide if a zone will be specified during resource deployment or if Azure will take that decision for the user. 
+  Keep in mind that regardless of the fact that NAT Gateway is placed in a specific zone it can serve traffic for resources in all zones. But if that zone becomes unavailable resources in other zones will loose internet connectivity. 
+
+  For design considerations, limitation and examples of zone-resiliency architecture please refer to [Microsoft documentation](https://learn.microsoft.com/en-us/azure/virtual-network/nat-gateway/nat-availability-zones).
+  EOF
+  default     = null
+  type        = string
+}
+
+variable "idle_timeout" {
+  description = "Connection IDLE timeout in minutes. Only for newly created resources."
+  default     = null
+  type        = number
+}
+
+variable "subnet_ids" {
+  description = "A map of subnet IDs what will be bound with this NAT Gateway. Value is the subnet ID, key value does not matter but should be unique, typically it can be a subnet name."
+  type        = map(string)
+}
+
+variable "create_pip" {
+  description = <<-EOF
+  Set `true` to create a Public IP resource that will be connected to newly created NAT Gateway. Not used when NAT Gateway is only sourced.
+
+  Setting this property to `false` has two meanings:
+  * when `existing_pip_name` is `null` simply no Public IP will be created
+  * when `existing_pip_name` is set to a name of an exiting Public IP resource it will be sourced and associated to this NAT Gateway.
+  EOF
+  default     = true
+  type        = bool
+}
+
+variable "existing_pip_name" {
+  description = "Name of an existing Public IP resource to associate with the NAT Gateway. Only for newly created resources."
+  default     = null
+  type        = string
+}
+
+variable "existing_pip_resource_group_name" {
+  description = "Name of a resource group hosting the Public IP resource specified in `existing_pip_name`. When omitted Resource Group specified in `resource_group_name` will be used."
+  default     = null
+  type        = string
+}
+
+variable "create_pip_prefix" {
+  description = <<-EOF
+  Set `true` to create a Public IP Prefix resource that will be connected to newly created NAT Gateway. Not used when NAT Gateway is only sourced.
+
+  Setting this property to `false` has two meanings:
+  * when `existing_pip_prefix_name` is `null` simply no Public IP Prefix will be created
+  * when `existing_pip_prefix_name` is set to a name of an exiting Public IP Prefix resource it will be sourced and associated to this NAT Gateway.
+  EOF
+  default     = false
+  type        = bool
+}
+
+variable "pip_prefix_length" {
+  description = <<-EOF
+  Number of bits of the Public IP Prefix. This basically specifies how many IP addresses are reserved. Azure default is `/28`.
+
+  This value can be between `0` and `31` but can be limited by limits set on Subscription level.
+  EOF
+  default     = null
+  type        = number
+}
+
+variable "existing_pip_prefix_name" {
+  description = "Name of an existing Public IP Prefix resource to associate with the NAT Gateway. Only for newly created resources."
+  default     = null
+  type        = string
+}
+
+variable "existing_pip_prefix_resource_group_name" {
+  description = "Name of a resource group hosting the Public IP Prefix resource specified in `existing_pip_name`. When omitted Resource Group specified in `resource_group_name` will be used."
+  default     = null
+  type        = string
+}

--- a/modules/natgw/versions.tf
+++ b/modules/natgw/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0, < 2.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.25"
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR introduces a new module that can be used to create a NAT Gateway.

## Motivation and Context

NAT GW is a the only Azure method of handling the outgoing traffic that can prevent SNAT port exhaustion.  Therefore a module that automates creation of this and related resources is introduced with this PR.

This module is capable of:
* creating a new NAT GW with either a Public IP or Public IP prefix 
* creating a new NAT GW and reusing existing Public IP or Public IP Prefix
* only sourcing an existing NAT GW.

In all 3 cases the NAT GW will be associated with subnets provided as a map of subnet IDs.

## How Has This Been Tested?

Sample code based on Common Ref Architecture was deployed. 

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->


- New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
