### PR TITLE
feat(module/appgw): add domain_name_label support for AppGW Public IP

### DIFF
--- a/modules/appgw/README.md
+++ b/modules/appgw/README.md
@@ -485,6 +485,7 @@ No modules.
 | <a name="input_capacity"></a> [capacity](#input\_capacity) | A number of Application Gateway instances. A value bewteen 1 and 125.<br><br>This property is not used when autoscaling is enabled. | `number` | `2` | no |
 | <a name="input_capacity_max"></a> [capacity\_max](#input\_capacity\_max) | Optional, maximum capacity for autoscaling. | `number` | `null` | no |
 | <a name="input_capacity_min"></a> [capacity\_min](#input\_capacity\_min) | When set enables autoscaling and becomes the minimum capacity. | `number` | `null` | no |
+| <a name="input_domain_name_label"></a> [domain\_name\_label](#input\_domain\_name\_label) | Label for the Domain Name. Will be used to make up the FQDN. If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system. | `string` | `null` | no |
 | <a name="input_enable_http2"></a> [enable\_http2](#input\_enable\_http2) | Enable HTTP2 on the Application Gateway. | `bool` | `false` | no |
 | <a name="input_location"></a> [location](#input\_location) | Location to place the Application Gateway in. | `string` | n/a | yes |
 | <a name="input_managed_identities"></a> [managed\_identities](#input\_managed\_identities) | A list of existing User-Assigned Managed Identities, which Application Gateway uses to retrieve certificates from Key Vault.<br><br>These identities have to have at least `GET` access to Key Vault's secrets. Otherwise Application Gateway will not be able to use certificates stored in the Vault. | `list(string)` | `null` | no |
@@ -506,5 +507,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_public_domain_name"></a> [public\_domain\_name](#output\_public\_domain\_name) | Public domain name assigned to the Application Gateway. |
 | <a name="output_public_ip"></a> [public\_ip](#output\_public\_ip) | A public IP assigned to the Application Gateway. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/appgw/main.tf
+++ b/modules/appgw/main.tf
@@ -40,7 +40,7 @@ resource "azurerm_public_ip" "this" {
 
   sku               = "Standard"
   allocation_method = "Static"
-  domain_name_label = try(var.domain_name_label, null)
+  domain_name_label = var.domain_name_label
   zones             = var.zones
   tags              = var.tags
 }

--- a/modules/appgw/main.tf
+++ b/modules/appgw/main.tf
@@ -40,6 +40,7 @@ resource "azurerm_public_ip" "this" {
 
   sku               = "Standard"
   allocation_method = "Static"
+  domain_name_label = try(var.domain_name_label, null)
   zones             = var.zones
   tags              = var.tags
 }

--- a/modules/appgw/outputs.tf
+++ b/modules/appgw/outputs.tf
@@ -2,3 +2,8 @@ output "public_ip" {
   description = "A public IP assigned to the Application Gateway."
   value       = azurerm_public_ip.this.ip_address
 }
+
+output "public_domain_name" {
+  description = "Public domain name assigned to the Application Gateway."
+  value       = azurerm_public_ip.this.fqdn
+}

--- a/modules/appgw/variables.tf
+++ b/modules/appgw/variables.tf
@@ -31,6 +31,12 @@ variable "name" {
   type        = string
 }
 
+variable "domain_name_label" {
+  description = "Label for the Domain Name. Will be used to make up the FQDN. If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system."
+  default     = null
+  type        = string
+}
+
 variable "managed_identities" {
   description = <<-EOF
   A list of existing User-Assigned Managed Identities, which Application Gateway uses to retrieve certificates from Key Vault.


### PR DESCRIPTION
## Description

With domain_name_label, Azure will generate a fqdn for the Azure Application Gateway Public IP in <domain_name_label>.<region>.cloudapp.azure.com format.

## Motivation and Context

For testing it makes easy to get an fqdn that resolves to Application Gateway public IP. 

## How Has This Been Tested?

Tested on example code with the domain_name_label attribute and removing it.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
