### PR TITLE
feat(module/virtual_machine): add ssh key-pair auth

### DIFF
--- a/modules/virtual_machine/.README.md
+++ b/modules/virtual_machine/.README.md
@@ -26,18 +26,19 @@ module "vm" {
 }
 ```
 
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.64 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0, < 2.0.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.7 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 2.64 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.7 |
 
 ## Modules
 
@@ -59,6 +60,7 @@ No modules.
 | <a name="input_accelerated_networking"></a> [accelerated\_networking](#input\_accelerated\_networking) | Enable Azure accelerated networking (SR-IOV) for all network interfaces | `bool` | `true` | no |
 | <a name="input_avset_id"></a> [avset\_id](#input\_avset\_id) | The identifier of the Availability Set to use. When using this variable, set `avzone = null`. | `string` | `null` | no |
 | <a name="input_avzone"></a> [avzone](#input\_avzone) | The availability zone to use, for example "1", "2", "3". Ignored if `enable_zones` is false. Conflicts with `avset_id`, in which case use `avzone = null`. | `string` | `"1"` | no |
+| <a name="input_avzones"></a> [avzones](#input\_avzones) | After provider version 3.x you need to specify in which availability zone(s) you want to place IP.<br>ie: for zone-redundant with 3 availability zone in current region value will be:<pre>["1","2","3"]</pre> | `list(string)` | `[]` | no |
 | <a name="input_bootstrap_share_name"></a> [bootstrap\_share\_name](#input\_bootstrap\_share\_name) | Azure File Share holding the bootstrap data. Should reside on `bootstrap_storage_account`. Bootstrapping is omitted if `bootstrap_share_name` is left at null. | `string` | `null` | no |
 | <a name="input_bootstrap_storage_account"></a> [bootstrap\_storage\_account](#input\_bootstrap\_storage\_account) | Existing storage account object for bootstrapping and for holding small-sized boot diagnostics. Usually the object is passed from a bootstrap module's output. | `any` | `null` | no |
 | <a name="input_custom_data"></a> [custom\_data](#input\_custom\_data) | The custom data to supply to the machine. This can be used as a cloud-init for Linux systems. | `string` | `null` | no |
@@ -70,17 +72,18 @@ No modules.
 | <a name="input_img_publisher"></a> [img\_publisher](#input\_img\_publisher) | The Azure Publisher identifier for a image which should be deployed. | `string` | `null` | no |
 | <a name="input_img_sku"></a> [img\_sku](#input\_img\_sku) | Virtual machine image SKU - list available with `az vm image list -o table --all --publisher foo` | `string` | `null` | no |
 | <a name="input_img_version"></a> [img\_version](#input\_img\_version) | Virtual machine image version - list available for a default `img_offer` with `az vm image list -o table --publisher foo --offer bar --all` | `string` | `"latest"` | no |
-| <a name="input_interfaces"></a> [interfaces](#input\_interfaces) | List of the network interface specifications.<br>The first should be the Management network interface, which does not participate in data filtering.<br>The remaining ones are the dataplane interfaces.<br><br>- `subnet_id`: Identifier of the existing subnet to use.<br>- `lb_backend_pool_id`: Identifier of the existing backend pool of the load balancer to associate.<br>- `enable_backend_pool`: If false, ignore `lb_backend_pool_id`. Default is false.<br>- `public_ip_address_id`: Identifier of the existing public IP to associate.<br>- `create_public_ip`: If true, create a public IP for the interface and ignore the `public_ip_address_id`. Default is false.<br><br>Example:<pre>[<br>  {<br>    subnet_id            = azurerm_subnet.my_mgmt_subnet.id<br>    public_ip_address_id = azurerm_public_ip.my_mgmt_ip.id<br>  },<br>  {<br>    subnet_id           = azurerm_subnet.my_pub_subnet.id<br>    lb_backend_pool_id  = module.inbound_lb.backend_pool_id<br>    enable_backend_pool = true<br>  },<br>]</pre> | `any` | n/a | yes |
+| <a name="input_interfaces"></a> [interfaces](#input\_interfaces) | List of the network interface specifications.<br>Options for an interface object:<br>- `name`                 - (required\|string) Interface name.<br>- `subnet_id`            - (required\|string) Identifier of an existing subnet to create interface in.<br>- `private_ip_address`   - (optional\|string) Static private IP to asssign to the interface. If null, dynamic one is allocated.<br>- `public_ip_address_id` - (optional\|string) Identifier of an existing public IP to associate.<br>- `create_public_ip`     - (optional\|bool) If true, create a public IP for the interface and ignore the `public_ip_address_id`. Default is false.<br>- `availability_zone`    - (optional\|string) Availability zone to create public IP in. If not specified, set based on `avzone` and `enable_zones`.<br>- `enable_ip_forwarding` - (optional\|bool) If true, the network interface will not discard packets sent to an IP address other than the one assigned. If false, the network interface only accepts traffic destined to its IP address.<br>- `enable_backend_pool`  - (optional\|bool) If true, associate interface with backend pool specified with `lb_backend_pool_id`. Default is false.<br>- `lb_backend_pool_id`   - (optional\|string) Identifier of an existing backend pool to associate interface with. Required if `enable_backend_pool` is true.<br>- `tags`                 - (optional\|map) Tags to assign to the interface and public IP (if created). Overrides contents of `tags` variable.<br><br>Example:<pre>[<br>  {<br>    name                 = "mgmt"<br>    subnet_id            = azurerm_subnet.my_mgmt_subnet.id<br>    public_ip_address_id = azurerm_public_ip.my_mgmt_ip.id<br>  },<br>  {<br>    name                = "public"<br>    subnet_id           = azurerm_subnet.my_pub_subnet.id<br>    lb_backend_pool_id  = module.inbound_lb.backend_pool_id<br>    enable_backend_pool = true<br>  },<br>]</pre> | `any` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | Region where to deploy and dependencies. | `string` | n/a | yes |
 | <a name="input_managed_disk_type"></a> [managed\_disk\_type](#input\_managed\_disk\_type) | Type of OS Managed Disk to create for the virtual machine. Possible values are `Standard_LRS`, `StandardSSD_LRS` or `Premium_LRS`. The `Premium_LRS` works only for selected `vm_size` values, details in Azure docs. | `string` | `"StandardSSD_LRS"` | no |
-| <a name="input_name"></a> [name](#input\_name) | Hostname of the virtual machine. | `string` | `"fw00"` | no |
+| <a name="input_name"></a> [name](#input\_name) | Virtual machine instance name. | `string` | n/a | yes |
 | <a name="input_os_disk_name"></a> [os\_disk\_name](#input\_os\_disk\_name) | Optional name of the OS disk to create for the virtual machine. If empty, the name is auto-generated. | `string` | `null` | no |
-| <a name="input_password"></a> [password](#input\_password) | Initial administrative password to use for the virtual machine. Mind the [Azure-imposed restrictions](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-password-requirements-when-creating-a-vm). | `string` | n/a | yes |
+| <a name="input_password"></a> [password](#input\_password) | Initial administrative password to use for the virtual machine. If not defined the `ssh_key` variable must be specified. Mind the [Azure-imposed restrictions](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-password-requirements-when-creating-a-vm). | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the existing resource group where to place the resources created. | `string` | n/a | yes |
+| <a name="input_ssh_keys"></a> [ssh\_keys](#input\_ssh\_keys) | A list of initial administrative SSH public keys that allow key-pair authentication. If not defined the `password` variable must be specified.<br><br>This is a list of strings, so each item should be the actual public key value. If you would like to load them from files instead, following method is available:<pre>[<br>  file("/path/to/public/keys/key_1.pub"),<br>  file("/path/to/public/keys/key_2.pub")<br>]</pre> | `list(string)` | `[]` | no |
 | <a name="input_standard_os"></a> [standard\_os](#input\_standard\_os) | Definition of the standard OS with "SimpleName" = "publisher,offer,sku" | `map` | <pre>{<br>  "CentOS": "OpenLogic,CentOS,7.6",<br>  "CoreOS": "CoreOS,CoreOS,Stable",<br>  "Debian": "credativ,Debian,9",<br>  "RHEL": "RedHat,RHEL,8.2",<br>  "SLES": "SUSE,SLES,12-SP2",<br>  "UbuntuServer": "Canonical,UbuntuServer,18.04-LTS",<br>  "openSUSE-Leap": "SUSE,openSUSE-Leap,15.1"<br>}</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to be associated with the resources created. | `map(any)` | `{}` | no |
 | <a name="input_username"></a> [username](#input\_username) | Initial administrative username to use for the virtual machine. Mind the [Azure-imposed restrictions](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-username-requirements-when-creating-a-vm). | `string` | n/a | yes |
-| <a name="input_vm_os_simple"></a> [vm\_os\_simple](#input\_vm\_os\_simple) | Allows user to specify a simple name for the OS required and auto populate the publisher, offer, sku parameters | `string` | `null` | no |
+| <a name="input_vm_os_simple"></a> [vm\_os\_simple](#input\_vm\_os\_simple) | Allows user to specify a simple name for the OS required and auto populate the publisher, offer, sku parameters | `string` | `"UbuntuServer"` | no |
 | <a name="input_vm_size"></a> [vm\_size](#input\_vm\_size) | Azure VM size (type) to be created. | `string` | `"Standard_D3_v2"` | no |
 
 ## Outputs
@@ -90,3 +93,4 @@ No modules.
 | <a name="output_interfaces"></a> [interfaces](#output\_interfaces) | List of interfaces. The elements of the list are `azurerm_network_interface` objects. The order is the same as `interfaces` input. |
 | <a name="output_principal_id"></a> [principal\_id](#output\_principal\_id) | The oid of Azure Service Principal of the created virtual machine. Usable only if `identity_type` contains SystemAssigned. |
 | <a name="output_public_ips"></a> [public\_ips](#output\_public\_ips) | A map of public IPs created |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/virtual_machine/main.tf
+++ b/modules/virtual_machine/main.tf
@@ -82,7 +82,14 @@ resource "azurerm_virtual_machine" "this" {
   }
 
   os_profile_linux_config {
-    disable_password_authentication = false
+    disable_password_authentication = var.password == null ? true : false
+    dynamic "ssh_keys" {
+      for_each = var.ssh_keys
+      content {
+        key_data = ssh_keys.value
+        path     = "/home/${var.username}/.ssh/authorized_keys"
+      }
+    }
   }
 
   # After converting to azurerm_linux_virtual_machine, an empty block boot_diagnostics {} will use managed storage. Want.

--- a/modules/virtual_machine/variables.tf
+++ b/modules/virtual_machine/variables.tf
@@ -95,9 +95,26 @@ variable "username" {
 }
 
 variable "password" {
-  description = "Initial administrative password to use for the virtual machine. Mind the [Azure-imposed restrictions](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-password-requirements-when-creating-a-vm)."
+  description = "Initial administrative password to use for the virtual machine. If not defined the `ssh_key` variable must be specified. Mind the [Azure-imposed restrictions](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-password-requirements-when-creating-a-vm)."
   type        = string
   sensitive   = true
+}
+
+variable "ssh_keys" {
+  description = <<-EOF
+  A list of initial administrative SSH public keys that allow key-pair authentication. If not defined the `password` variable must be specified.
+  
+  This is a list of strings, so each item should be the actual public key value. If you would like to load them from files instead, following method is available:
+
+  ```
+  [
+    file("/path/to/public/keys/key_1.pub"),
+    file("/path/to/public/keys/key_2.pub")
+  ]
+  ```
+  EOF
+  default     = []
+  type        = list(string)
 }
 
 variable "managed_disk_type" {


### PR DESCRIPTION
## Description

Add support for key-based auth in `virtual_machine` module.

## Motivation and Context

Extend module flexibility.

## How Has This Been Tested?

Apply custom example code.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
