### PR TITLE
ci(module/natgw): adding missing makefile to fix failing CI pipelines

### DIFF
--- a/modules/natgw/Makefile
+++ b/modules/natgw/Makefile
@@ -1,0 +1,3 @@
+validate:
+	@../../makefile.sh validate
+	


### PR DESCRIPTION
## Description

Add `Makefile` to NatGW module

## Motivation and Context

`Makefile` for NaTGW module is missing due to which the release pipeline fail.

## How Has This Been Tested?

makefile was run locally 

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
