### PR TITLE
fix(module/vmseries): fix destroy sequence for LB backends

### DIFF
--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -35,6 +35,11 @@ resource "azurerm_network_interface_backend_address_pool_association" "this" {
   backend_address_pool_id = each.value.lb_backend_pool_id
   ip_configuration_name   = azurerm_network_interface.this[each.key].ip_configuration[0].name
   network_interface_id    = azurerm_network_interface.this[each.key].id
+
+  depends_on = [
+    azurerm_network_interface.this,
+    azurerm_virtual_machine.this
+  ]
 }
 
 resource "azurerm_virtual_machine" "this" {


### PR DESCRIPTION
## Description

For destroy operations, force the LB backend association to be destroyed 1<sup>st</sup>. 

## Motivation and Context

W/o that manual dependency, during destroy operations, a race condition can happen, when VM is being destroyed before the NIC - LB backend association. In such case the destroy operation fails with an error. The problem is not the order but the fact that the VM is in a 'destroying' phase while the the destroy operation is run on the association. 

This fix can also close #199 as the problem described in that issue is triggered only when a destroy operation 1<sup>st</sup> fails due to the described race condition. 

## How Has This Been Tested?

Existing code/example have been run to prove that the race condition cannot be reproduced.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
