### PR TITLE
ci: introduce end2end tests with terraform plan/apply

### DIFF
--- a/.github/actions/plan_apply/action.yml
+++ b/.github/actions/plan_apply/action.yml
@@ -11,22 +11,27 @@ inputs:
     description: When set to true runs also apply
     type: boolean
     default: false
-  indepotency:
+  idempotence:
     description: When set to true runs plan to on already applied configuration
     type: boolean
     default: true
+
 runs:
   using: "composite"
   steps:
+
     - name: setup Terraform
       uses: hashicorp/setup-terraform@v2
       with:
         terraform_version: ${{ inputs.tf_version }}
 
-    - name: set UUID value
+    - name: set UUID and provider values value
       id: uuid
       shell: bash
-      run: echo "::set-output name=uuid::$(uuidgen | tr '[:upper:]' '[:lower:]')"
+      env:
+        TPATH: ${{ inputs.path }}
+      run: |
+        echo "uuid=$(uuidgen | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
     - name: login to Azure
       uses: azure/login@v1
@@ -35,47 +40,59 @@ runs:
         tenant-id: ${{ env.ARM_TENANT_ID }}
         subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
 
-    - name: run plan
+    - name: plan infrastructure
       id: plan
-      if: ${{ ! inputs.do_apply }}
+      if: inputs.do_apply == 'false'
       env:
         TPATH: ${{ inputs.path }}
         ARM_USE_OIDC: true
         UUID: ${{ steps.uuid.outputs.uuid }}
       shell: bash
       run: |
+        echo "::group::TERRAFORM PLAN"
         cd "$GITHUB_WORKSPACE/$TPATH"
-        make plan
+          make plan
+        echo "::endgroup::"
 
-    - name: run apply
-      if: inputs.do_apply
+    - name: create infrastructure
+      id: apply
+      if: inputs.do_apply == 'true'
       env:
         TPATH: ${{ inputs.path }}
         ARM_USE_OIDC: true
         UUID: ${{ steps.uuid.outputs.uuid }}
       shell: bash
       run: |
+        echo "::group::TERRAFORM APPLY"
         cd "$GITHUB_WORKSPACE/$TPATH"
         make apply
+        echo "::endgroup::"
 
-    - name: test indepotency
-      if: inputs.do_apply && inputs.indepotency
+    - name: test idempotence
+      id: idempotence
+      if: inputs.do_apply == 'true' && inputs.idempotence == 'true'
       env:
         TPATH: ${{ inputs.path }}
         ARM_USE_OIDC: true
         UUID: ${{ steps.uuid.outputs.uuid }}
       shell: bash
       run: |
+        echo "::group::TERRAFORM IDEMPOTENCE"
         cd "$GITHUB_WORKSPACE/$TPATH"
-        make indepotency
+        make idempotence
+        echo "::endgroup::"
 
     - name: run destroy
-      if: inputs.do_apply && always()
+      id: destroy
+      if: inputs.do_apply == 'true'
       env:
         TPATH: ${{ inputs.path }}
         ARM_USE_OIDC: true
         UUID: ${{ steps.uuid.outputs.uuid }}
+        IDEMPOTENCE: ${{ inputs.idempotence }}
       shell: bash
       run: |
         cd "$GITHUB_WORKSPACE/$TPATH"
+        echo "::group::TERRAFORM DESTROY"
         make destroy
+        echo "::endgroup::"

--- a/.github/actions/sub_cleanup/action.yml
+++ b/.github/actions/sub_cleanup/action.yml
@@ -1,0 +1,34 @@
+name: 'Subscription cleanup'
+description: 'Cleans up subscription in case the job was cancelled.'
+runs:
+  using: "composite"
+  steps:
+
+    - name: login to Azure
+      uses: azure/login@v1
+      with:
+        client-id: ${{ env.ARM_CLIENT_ID }}
+        tenant-id: ${{ env.ARM_TENANT_ID }}
+        subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
+
+    - name: delete resource groups
+      shell: bash
+      run: |
+        echo "::group::CLEANUP"
+
+        set +e
+        for RG in $(az group list --query "[?properties.provisioningState=='Succeeded']" | jq -r '.[] | select(.name | contains("ghci")) | .name'); do 
+          echo "  deleting: $RG"
+          az group delete -g ${RG} -y --no-wait
+
+          E_CODE=$?
+          # check the az group delete exit code
+          if [ ! $E_CODE -eq 0 ] && [ ! $E_CODE -eq 3 ]; then
+            # when exit code is 3 it means that the group is no longer available (deleted for example)
+            # hence we skip that error as it is not relevant for us
+            # we do honor every other non 0 exit code though
+            exit $E_CODE
+          fi
+        done
+        set -e
+        echo "::endgroup::"

--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -18,4 +18,4 @@ on:
 jobs:
   lint_pr_title:
     name: Lint PR
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/lint_pr_title.yml@v0.4.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/lint_pr_title.yml@v1.0.0

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -4,13 +4,12 @@ run-name: "CI pipeline for PR - (#${{ github.event.number }}) ${{ github.event.p
 permissions:
   contents: read
   actions: read
-
+  id-token: write
 
 on:
   pull_request:
     types:
       - opened
-      - edited
       - reopened
       - synchronize
       - ready_for_review
@@ -19,8 +18,9 @@ on:
 jobs:
   pr_ci_wrkflw:
     name: Run CI
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/pr_ci.yml@v0.4.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/pr_ci.yml@v1.0.0
     secrets: inherit
+    if: github.actor != 'dependabot[bot]'
     with:
       cloud: azure
       tf_version: 1.2 1.3 1.4

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -5,7 +5,7 @@ run-name: "Continous Release"
 permissions:
   contents: write
   issues: read
-
+  id-token: write
 
 on:
   workflow_dispatch:
@@ -15,9 +15,10 @@ on:
 jobs:
   release_wrkflw:
     name: Do release
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/release_ci.yml@v0.4.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/release_ci.yml@v1.0.0
     secrets: inherit
     with:
       cloud: azure
       max_parallel: 10
       tf_version: 1.2 1.3 1.4
+      do_apply: true

--- a/examples/common_vmseries/Makefile
+++ b/examples/common_vmseries/Makefile
@@ -2,30 +2,23 @@ init:
 	@../../makefile.sh init
 
 prep_vars: check_uuid
-	@../../makefile.sh prep_vars
+	@if [ ! -f ghci.tfvars ]; then sed -E "s/example-/${PREFIX}/g;s/^resource_group_name.*/resource_group_name = \"${RG}\"/g" example.tfvars > ghci.tfvars; fi
 
 validate:
 	@../../makefile.sh validate
 
-plan: check_uuid init
-	@../../makefile.sh plan '${TF_PARAMS}'
+plan: init prep_vars
+	@../../makefile.sh plan
 
-plan_file: check_uuid init
-	@../../makefile.sh plan_file '${TF_PARAMS}'
+apply: init prep_vars
+	@../../makefile.sh apply
 
-apply_file:
-	@../../makefile.sh apply_file
+idempotence:
+	@../../makefile.sh idempotence
 
-apply: check_uuid init plan_file apply_file
-
-idempotence: check_uuid
-	@../../makefile.sh idempotence '${TF_PARAMS}'
-
-destroy: check_uuid
-	@../../makefile.sh destroy '${TF_PARAMS}'
-
-delete_rg: check_uuid
-	@../../makefile.sh delete_rg '${PREFIX}${RG}'
+destroy:
+	@../../makefile.sh destroy
+	@rm ghci.tfvars
 
 check_uuid:
 ifndef UUID
@@ -35,5 +28,5 @@ ifndef UUID
 else
 RG := $(shell echo ${UUID} | cut -d '-' -f 1,5)
 PREFIX := ghci$(shell echo ${UUID} | cut -d '-' -f 2)-
-TF_PARAMS := -var-file=example.tfvars -var resource_group_name=${RG} -var name_prefix=${PREFIX}
+STORAGE := $(shell echo ${UUID} | cut -d '-' -f 2,3,4 | tr -d '-')
 endif

--- a/examples/dedicated_vmseries/Makefile
+++ b/examples/dedicated_vmseries/Makefile
@@ -2,30 +2,24 @@ init:
 	@../../makefile.sh init
 
 prep_vars: check_uuid
-	@../../makefile.sh prep_vars
+	@if [ ! -f ghci.tfvars ]; then sed -E "s/example-/${PREFIX}/g;s/xmplbootstrapdedicated/${STORAGE}/g;s/^resource_group_name.*/resource_group_name = \"${RG}\"/g" example.tfvars > ghci.tfvars; fi
+	@if [ ! -f files/init-cfg.txt ]; then  cp files/init-cfg.sample.txt files/init-cfg.txt; fi
 
 validate:
 	@../../makefile.sh validate
 
-plan: check_uuid init
-	@../../makefile.sh plan '${TF_PARAMS}'
+plan: init prep_vars
+	@../../makefile.sh plan
 
-plan_file: check_uuid init
-	@../../makefile.sh plan_file '${TF_PARAMS}'
+apply: init prep_vars
+	@../../makefile.sh apply
 
-apply_file:
-	@../../makefile.sh apply_file
+idempotence:
+	@../../makefile.sh idempotence
 
-apply: check_uuid init plan_file apply_file
-
-idempotence: check_uuid
-	@../../makefile.sh idempotence '${TF_PARAMS}'
-
-destroy: check_uuid
-	@../../makefile.sh destroy '${TF_PARAMS}'
-
-delete_rg: check_uuid
-	@../../makefile.sh delete_rg '${PREFIX}${RG}'
+destroy:
+	@../../makefile.sh destroy
+	@rm ghci.tfvars
 
 check_uuid:
 ifndef UUID
@@ -35,5 +29,5 @@ ifndef UUID
 else
 RG := $(shell echo ${UUID} | cut -d '-' -f 1,5)
 PREFIX := ghci$(shell echo ${UUID} | cut -d '-' -f 2)-
-TF_PARAMS := -var-file=example.tfvars -var resource_group_name=${RG} -var name_prefix=${PREFIX}
+STORAGE := $(shell echo ${UUID} | cut -d '-' -f 2,3,4 | tr -d '-')
 endif

--- a/examples/dedicated_vmseries_and_autoscale/Makefile
+++ b/examples/dedicated_vmseries_and_autoscale/Makefile
@@ -2,30 +2,23 @@ init:
 	@../../makefile.sh init
 
 prep_vars: check_uuid
-	@../../makefile.sh prep_vars
+	@if [ ! -f ghci.tfvars ]; then sed -E "s/example-/${PREFIX}/g;s/^resource_group_name.*/resource_group_name = \"${RG}\"/g" example.tfvars > ghci.tfvars; fi
 
 validate:
 	@../../makefile.sh validate
 
-plan: check_uuid init
-	@../../makefile.sh plan '${TF_PARAMS}'
+plan: init prep_vars
+	@../../makefile.sh plan
 
-plan_file: check_uuid init
-	@../../makefile.sh plan_file '${TF_PARAMS}'
+apply: init prep_vars
+	@../../makefile.sh apply
 
-apply_file:
-	@../../makefile.sh apply_file
+idempotence:
+	@../../makefile.sh idempotence
 
-apply: check_uuid init plan_file apply_file
-
-idempotence: check_uuid
-	@../../makefile.sh idempotence '${TF_PARAMS}'
-
-destroy: check_uuid
-	@../../makefile.sh destroy '${TF_PARAMS}'
-
-delete_rg: check_uuid
-	@../../makefile.sh delete_rg '${PREFIX}${RG}'
+destroy:
+	@../../makefile.sh destroy
+	@rm ghci.tfvars
 
 check_uuid:
 ifndef UUID
@@ -35,5 +28,5 @@ ifndef UUID
 else
 RG := $(shell echo ${UUID} | cut -d '-' -f 1,5)
 PREFIX := ghci$(shell echo ${UUID} | cut -d '-' -f 2)-
-TF_PARAMS := -var-file=example.tfvars -var resource_group_name=${RG} -var name_prefix=${PREFIX}
+STORAGE := $(shell echo ${UUID} | cut -d '-' -f 2,3,4 | tr -d '-')
 endif

--- a/examples/standalone_panorama/Makefile
+++ b/examples/standalone_panorama/Makefile
@@ -1,5 +1,32 @@
 init:
 	@../../makefile.sh init
 
+prep_vars: check_uuid
+	@if [ ! -f ghci.tfvars ]; then sed -E "s/example-/${PREFIX}/g;s/^resource_group_name.*/resource_group_name = \"${RG}\"/g" example.tfvars > ghci.tfvars; fi
+
 validate:
 	@../../makefile.sh validate
+
+plan: init prep_vars
+	@../../makefile.sh plan
+
+apply: init prep_vars
+	@../../makefile.sh apply
+
+idempotence:
+	@../../makefile.sh idempotence
+
+destroy:
+	@../../makefile.sh destroy
+	@rm ghci.tfvars
+
+check_uuid:
+ifndef UUID
+	$(info Missing UUID, generate one for yourself using command:)
+	$(info export UUID=$$(uuidgen | tr '[:upper:]' '[:lower:]'))
+	$(error )
+else
+RG := $(shell echo ${UUID} | cut -d '-' -f 1,5)
+PREFIX := ghci$(shell echo ${UUID} | cut -d '-' -f 2)-
+STORAGE := $(shell echo ${UUID} | cut -d '-' -f 2,3,4 | tr -d '-')
+endif

--- a/examples/standalone_vmseries/Makefile
+++ b/examples/standalone_vmseries/Makefile
@@ -2,30 +2,23 @@ init:
 	@../../makefile.sh init
 
 prep_vars: check_uuid
-	@../../makefile.sh prep_vars
+	@if [ ! -f ghci.tfvars ]; then sed -E "s/example-/${PREFIX}/g;s/^resource_group_name.*/resource_group_name = \"${RG}\"/g" example.tfvars > ghci.tfvars; fi
 
 validate:
 	@../../makefile.sh validate
 
-plan: check_uuid init
-	@../../makefile.sh plan '${TF_PARAMS}'
+plan: init prep_vars
+	@../../makefile.sh plan
 
-plan_file: check_uuid init
-	@../../makefile.sh plan_file '${TF_PARAMS}'
+apply: init prep_vars
+	@../../makefile.sh apply
 
-apply_file:
-	@../../makefile.sh apply_file
+idempotence:
+	@../../makefile.sh idempotence
 
-apply: check_uuid init plan_file apply_file
-
-idempotence: check_uuid
-	@../../makefile.sh idempotence '${TF_PARAMS}'
-
-destroy: check_uuid
-	@../../makefile.sh destroy '${TF_PARAMS}'
-
-delete_rg: check_uuid
-	@../../makefile.sh delete_rg '${PREFIX}${RG}'
+destroy:
+	@../../makefile.sh destroy
+	@rm ghci.tfvars
 
 check_uuid:
 ifndef UUID
@@ -35,5 +28,5 @@ ifndef UUID
 else
 RG := $(shell echo ${UUID} | cut -d '-' -f 1,5)
 PREFIX := ghci$(shell echo ${UUID} | cut -d '-' -f 2)-
-TF_PARAMS := -var-file=example.tfvars -var resource_group_name=${RG} -var name_prefix=${PREFIX}
+STORAGE := $(shell echo ${UUID} | cut -d '-' -f 2,3,4 | tr -d '-')
 endif

--- a/makefile.sh
+++ b/makefile.sh
@@ -1,112 +1,49 @@
 #!/bin/bash
 
 set -o pipefail
-
-TFPLAN=gh_ci.tfplan
+set -e
 
 COMMAND=$1
-TF_OPTIONS=${@: 2}
 
 case $1 in
   init)
-    set -e
     echo "::  INITIALIZING TERRAFORM  ::"
     terraform init | nl -bn
     echo
-    set +e
     ;;
 
   validate)
-    set -e
     echo "::  INITIALIZING TERRAFORM  ::"
     terraform init -backend=false | nl -bn
     echo
     echo "::  VALIDATING CODE  ::"
     terraform validate | nl -bn
     echo
-    set +e
     ;;
 
   plan)
-    set -e
     echo "::  PLANNING INFRASTRUCTURE  ::"
-    terraform plan ${TF_OPTIONS} | nl -bn
+    terraform plan -var-file=ghci.tfvars | nl -bn
     echo
-    set +e
     ;;
 
-  plan_file)
-    set -e
-    echo "::  CREATING INFRASTRUCTURE PLAN FILE  ::"
-    terraform plan ${TF_OPTIONS} -out ${TFPLAN} | nl -bn
-    echo
-    set +e
-    ;;
-
-  apply_file)
-    echo "::  APPLYING INFRASTRUCTURE PLAN FILE  ::"
-    for INDEX in {1..3}; do
-      terraform apply ${TFPLAN} | nl -bn
-      TF_FAILED=$?
-      if [ $TF_FAILED -eq 0 ]; then
-        break
-      else
-        TF_FAILED=1
-      fi
-      sleep 5
-    done
-
-    if [ $TF_FAILED -ne 0 -a "$GITHUB_ACTIONS" ]; then
-      touch APPLY
-    fi
+  apply)
+    echo "::  APPLYING INFRASTRUCTURE  ::"
+    terraform apply -auto-approve -var-file=ghci.tfvars | nl -bn
     echo
     ;;
 
   idempotence)
     echo "::  TESTING IDEMPOTENCE  ::"
-    terraform plan -detailed-exitcode ${TF_OPTIONS} | nl -bn
-    if [ $? -ne 0 -a "$GITHUB_ACTIONS" ]; then
-        touch IDEMPOTENCE
-    fi
+    terraform plan -detailed-exitcode -var-file=ghci.tfvars | nl -bn
     echo
     ;;
 
   destroy)
     echo "::  DESTROYING INFRASTRUCTURE  ::"
-    TF_FAILED=0
-
-    # for Azure, due to API bugs, we try to run destroy maximum 3 times
-    for INDEX in {1..3}; do
-      terraform destroy -auto-approve ${TF_OPTIONS}  | nl -bn
-      TF_FAILED=$?
-      if [ $TF_FAILED -eq 0 ]; then
-        if [ -f "${TFPLAN}" ]; then
-          echo "::  REMOVING INFRASTRUCTURE PLAN FILE  ::"
-          rm ${TFPLAN} | nl -bn
-        fi
-        echo
-        break
-      else
-        TF_FAILED=1
-      fi
-      sleep 5
-    done
-
-    if [ $TF_FAILED -ne 0 -a "$GITHUB_ACTIONS" ]; then
-      touch DESTROY
-    fi
+    terraform destroy -auto-approve -var-file=ghci.tfvars  | nl -bn
     ;;
 
-  delete_rg)
-    echo "::  DELETING INFRASTRUCTURE  ::"
-    TF_PARAMS=${@: 2}
-    set -e
-    for G in ${TF_PARAMS[@]}; do
-      az group delete -g "$G" -y --no-wait | nl -bn
-    done
-    echo
-    set +e
-    ;;
   *)
     echo "ERROR: wrong param passed:: [$1]"
     exit 1


### PR DESCRIPTION
## Description

Introducing possibility to run `terraform plan/apply` on examples.

## Motivation and Context

All tests available up to this point were just static tests. With this PR we are extending the tests by providing a framework for running the actual deployments. The most important changes are:

* all `pre-commit` check will be run w/o any changes
* for each PR:
  * differences between the current and default (main) branch will be detected
  * dependencies between modules and examples will be detected
  * `validate` will be run on all changed and dependent modules
  * `plan` will be run on all changed and dependent modules
* for each release, on each module and example:
  * `validate` will be run
  * `apply` will be run
  * `plan` will be run on existing infrastructure to test idempotency 
  * `destroy` will be run
* any of the steps that fail stops the whole workflow run
* if a workflow is stopped due to an error or cancelled, a cleanup job will be run to delete all test infrastructure

## How Has This Been Tested?

All workflows were run on a copy of this repository

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->


- New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
