### PR TITLE
ci: skip provider registration during plan/apply

### DIFF
--- a/.github/actions/plan_apply/action.yml
+++ b/.github/actions/plan_apply/action.yml
@@ -47,6 +47,7 @@ runs:
         TPATH: ${{ inputs.path }}
         ARM_USE_OIDC: true
         UUID: ${{ steps.uuid.outputs.uuid }}
+        ARM_SKIP_PROVIDER_REGISTRATION: true
       shell: bash
       run: |
         echo "::group::TERRAFORM PLAN"
@@ -61,6 +62,7 @@ runs:
         TPATH: ${{ inputs.path }}
         ARM_USE_OIDC: true
         UUID: ${{ steps.uuid.outputs.uuid }}
+        ARM_SKIP_PROVIDER_REGISTRATION: true
       shell: bash
       run: |
         echo "::group::TERRAFORM APPLY"
@@ -75,6 +77,7 @@ runs:
         TPATH: ${{ inputs.path }}
         ARM_USE_OIDC: true
         UUID: ${{ steps.uuid.outputs.uuid }}
+        ARM_SKIP_PROVIDER_REGISTRATION: true
       shell: bash
       run: |
         echo "::group::TERRAFORM IDEMPOTENCE"
@@ -89,7 +92,7 @@ runs:
         TPATH: ${{ inputs.path }}
         ARM_USE_OIDC: true
         UUID: ${{ steps.uuid.outputs.uuid }}
-        IDEMPOTENCE: ${{ inputs.idempotence }}
+        ARM_SKIP_PROVIDER_REGISTRATION: true
       shell: bash
       run: |
         cd "$GITHUB_WORKSPACE/$TPATH"


### PR DESCRIPTION
## Description

Avoid provider registration with Terraform. 

## Motivation and Context

When terraform is 1st run against a subscription, the Azure resource provider tries to register all resource providers, regardless if they will be used or not. For automation purposes, when the account has limited access, this will cause the CI workflow to fail.

To avoid that, the `skip_provider_registration` property can be used in the provider block to control that functionality. Since this would require modifications to all examples, an environment variable `ARM_SKIP_PROVIDER_REGISTRATION=true` will be used in the plan/apply action instead.

A risk that the CI will fail due to missing resource providers is minimum because:
- all examples were already deployed in the subscription used by the CI workflows
- we use quite typical resources - providers for these are registered in every subscription by default.

## How Has This Been Tested?

See CI results below.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- CI Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
