### PR TITLE
docs: Update pre-commit and REAMDEs for SWFW Hub

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
         args: [
           '--args=--sort=false',
           '--args=--lockfile=false',
+          '--args=--indent=3',
         ]
       - id: terraform_tflint
         args: [

--- a/examples/common_vmseries/README.md
+++ b/examples/common_vmseries/README.md
@@ -136,14 +136,15 @@ To remove the deployed infrastructure run:
 terraform destroy
 ```
 
+## Reference
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
+### Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2, < 2.0 |
 
-## Providers
+### Providers
 
 | Name | Version |
 |------|---------|
@@ -151,7 +152,7 @@ terraform destroy
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
 | <a name="provider_local"></a> [local](#provider\_local) | n/a |
 
-## Modules
+### Modules
 
 | Name | Source | Version |
 |------|--------|---------|
@@ -164,7 +165,7 @@ terraform destroy
 | <a name="module_vmseries"></a> [vmseries](#module\_vmseries) | ../../modules/vmseries | n/a |
 | <a name="module_appgw"></a> [appgw](#module\_appgw) | ../../modules/appgw | n/a |
 
-## Resources
+### Resources
 
 | Name | Type |
 |------|------|
@@ -174,7 +175,7 @@ terraform destroy
 | [random_password.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
-## Inputs
+### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -198,7 +199,7 @@ terraform destroy
 | <a name="input_vmseries"></a> [vmseries](#input\_vmseries) | Map of virtual machines to create to run VM-Series - inbound firewalls. Following properties are supported:<br><br>- `name` : name of the VMSeries virtual machine.<br>- `vm_size` : size of the VMSeries virtual machine, when specified overrides `var.vmseries_vm_size`.<br>- `version` : PanOS version, when specified overrides `var.vmseries_version`.<br>- `vnet_key` : a key of a VNET defined in the `var.vnets` map. This value will be used during network interfaces creation.<br>- `add_to_appgw_backend` : bool, `false` by default, set this to `true` to add this backend to an Application Gateway.<br>- `avzone`: the Azure Availability Zone identifier ("1", "2", "3"). Default is "1".<br>- `availability_set_name` : a name of an Availability Set as declared in `availability_set` property. Specify when HA is required but cannot go for zonal deployment.<br><br>- `bootstrap_options` : string, optional bootstrap options to pass to VM-Series instances, semicolon separated values. When defined this precedence over `bootstrap_storage`<br>- `bootstrap_storage` : a map containing definition of the bootstrap package content. When present triggers a creation of a File Share in an existing Storage Account, following properties supported:<br>  - `name` : a name of a key in `var.bootstrap_storage` variable defining a Storage Account<br>  - `static_files` : a map where key is a path to a file, value is the location of the file in the bootstrap package (file share). All files in this map are copied 1:1 to the bootstrap package<br>  - `template_bootstrap_xml` : path to the `bootstrap.xml` template. When defined it will trigger creation of the `bootstrap.xml` file and the file will be uploaded to the storage account. This is a simple `day 0` configuration file that should set up only basic networking. Specifying this property forces additional properties that are required to properly template the file. They can be defined per each VM or globally for all VMs (in this case place them in the bootstrap storage definition). The properties are listed below.<br>  - `public_snet_key` : required, name of the key in `var.vnets` map defining a public subnet, required to calculate the Azure router IP for the public subnet.<br>  - `private_snet_key` : required, name of the key in `var.vnets` map defining a private subnet, required to calculate the Azure router IP for the private subnet.<br>  - `intranet_cidr` : optional, CIDR of the private networks required to build a general static route to resources protected by this firewall, when skipped the 1st CIDR from `vnet_name` address space will be used.<br>  - `ai_update_interval` : if Application Insights are used this property can override the default metrics update interval (in minutes).<br><br>- `interfaces` : configuration of all NICs assigned to a VM. A list of maps, each map is a NIC definition. Notice that the order DOES matter. NICs are attached to VMs in Azure in the order they are defined in this list, therefore the management interface has to be defined first. Following properties are available:<br>  - `name`: string that will form the NIC name<br>  - `subnet_key` : (string) a key of a subnet as defined in `var.vnets`<br>  - `create_pip` : (boolean) flag to create Public IP for an interface, defaults to `false`<br>  - `public_ip_name` : (string) when `create_pip` is set to `false` a name of a Public IP resource that should be associated with this Network Interface<br>  - `public_ip_resource_group` : (string) when associating an existing Public IP resource, name of the Resource Group the IP is placed in, defaults to the `var.resource_group_name`<br>  - `load_balancer_key` : (string) key of a Load Balancer defined in the `var.loadbalancers`  variable, defaults to `null`<br>  - `private_ip_address` : (string) a static IP address that should be assigned to an interface, defaults to `null` (in that case DHCP is used)<br><br>Example:<pre>{<br>  "fw01" = {<br>    name = "firewall01"<br>    bootstrap_storage = {<br>      name                   = "storageaccountname"<br>      static_files           = { "files/init-cfg.txt" = "config/init-cfg.txt" }<br>      template_bootstrap_xml = "templates/bootstrap_common.tmpl"<br>      public_snet_key        = "public"<br>      private_snet_key       = "private"<br>    }<br>    avzone   = 1<br>    vnet_key = "trust"<br>    interfaces = [<br>      {<br>        name               = "mgmt"<br>        subnet_key         = "mgmt"<br>        create_pip         = true<br>        private_ip_address = "10.0.0.1"<br>      },<br>      {<br>        name                 = "trust"<br>        subnet_key           = "private"<br>        private_ip_address   = "10.0.1.1"<br>        load_balancer_key    = "private_lb"<br>      },<br>      {<br>        name                 = "untrust"<br>        subnet_key           = "public"<br>        private_ip_address   = "10.0.2.1"<br>        load_balancer_key    = "public_lb"<br>        public_ip_name       = "existing_public_ip"<br>      }<br>    ]<br>  }<br>}</pre> | `any` | n/a | yes |
 | <a name="input_appgws"></a> [appgws](#input\_appgws) | A map defining all Application Gateways in the current deployment.<br><br>For detailed documentation on how to configure this resource, for available properties, especially for the defaults and the `rules` property refer to [module documentation](https://github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules/blob/main/modules/appgw/README.md).<br><br>Following properties are supported:<br>- `name` : name of the Application Gateway.<br>- `vnet_key` : a key of a VNET defined in the `var.vnets` map.<br>- `subnet_key` : a key of a subnet as defined in `var.vnets`. This has to be a subnet dedicated to Application Gateways v2.<br>- `zones` : for zonal deployment this is a list of all zones in a region - this property is used by both: the Application Gateway and the Public IP created in front of the AppGW.<br>- `capacity` : (optional) number of Application Gateway instances, not used when autoscalling is enabled (see `capacity_min`)<br>- `capacity_min` : (optional) when set enables autoscaling and becomes the minimum capacity<br>- `capacity_max` : (optional) maximum capacity for autoscaling<br>- `enable_http2` : enable HTTP2 support on the Application Gateway<br>- `waf_enabled` : (optional) enables WAF Application Gateway, defining WAF rules is not supported, defaults to `false`<br>- `vmseries_public_nic_name` : name of the public VMSeries interface as defined in `interfaces` property.<br>- `managed_identities` : (optional) a list of existing User-Assigned Managed Identities, which Application Gateway uses to retrieve certificates from Key Vault<br>- `ssl_policy_type` : (optional) type of an SSL policy, defaults to `Predefined`<br>- `ssl_policy_name` : (optional) name of an SSL policy, for `ssl_policy_type` set to `Predefined`<br>- `ssl_policy_min_protocol_version` : (optional) minimum version of the TLS protocol for SSL Policy, for `ssl_policy_type` set to `Custom`<br>- `ssl_policy_cipher_suites` : (optional) a list of accepted cipher suites, for `ssl_policy_type` set to `Custom`<br>- `ssl_profiles` : (optional) a map of SSL profiles that can be later on referenced in HTTPS listeners by providing a name of the profile in the `ssl_profile_name` property | `map` | `{}` | no |
 
-## Outputs
+### Outputs
 
 | Name | Description |
 |------|-------------|

--- a/examples/dedicated_vmseries/README.md
+++ b/examples/dedicated_vmseries/README.md
@@ -138,14 +138,15 @@ To remove the deployed infrastructure run:
 terraform destroy
 ```
 
+## Reference
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
+### Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2, < 2.0 |
 
-## Providers
+### Providers
 
 | Name | Version |
 |------|---------|
@@ -153,7 +154,7 @@ terraform destroy
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
 | <a name="provider_local"></a> [local](#provider\_local) | n/a |
 
-## Modules
+### Modules
 
 | Name | Source | Version |
 |------|--------|---------|
@@ -166,7 +167,7 @@ terraform destroy
 | <a name="module_vmseries"></a> [vmseries](#module\_vmseries) | ../../modules/vmseries | n/a |
 | <a name="module_appgw"></a> [appgw](#module\_appgw) | ../../modules/appgw | n/a |
 
-## Resources
+### Resources
 
 | Name | Type |
 |------|------|
@@ -176,7 +177,7 @@ terraform destroy
 | [random_password.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
-## Inputs
+### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -200,7 +201,7 @@ terraform destroy
 | <a name="input_vmseries"></a> [vmseries](#input\_vmseries) | Map of virtual machines to create to run VM-Series - inbound firewalls. Following properties are supported:<br><br>- `name` : name of the VMSeries virtual machine.<br>- `vm_size` : size of the VMSeries virtual machine, when specified overrides `var.vmseries_vm_size`.<br>- `version` : PanOS version, when specified overrides `var.vmseries_version`.<br>- `vnet_key` : a key of a VNET defined in the `var.vnets` map. This value will be used during network interfaces creation.<br>- `add_to_appgw_backend` : bool, `false` by default, set this to `true` to add this backend to an Application Gateway.<br>- `avzone`: the Azure Availability Zone identifier ("1", "2", "3"). Default is "1".<br>- `availability_set_name` : a name of an Availability Set as declared in `availability_set` property. Specify when HA is required but cannot go for zonal deployment.<br><br>- `bootstrap_options` : string, optional bootstrap options to pass to VM-Series instances, semicolon separated values. When defined this precedence over `bootstrap_storage`<br>- `bootstrap_storage` : a map containing definition of the bootstrap package content. When present triggers a creation of a File Share in an existing Storage Account, following properties supported:<br>  - `name` : a name of a key in `var.bootstrap_storage` variable defining a Storage Account<br>  - `static_files` : a map where key is a path to a file, value is the location of the file in the bootstrap package (file share). All files in this map are copied 1:1 to the bootstrap package<br>  - `template_bootstrap_xml` : path to the `bootstrap.xml` template. When defined it will trigger creation of the `bootstrap.xml` file and the file will be uploaded to the storage account. This is a simple `day 0` configuration file that should set up only basic networking. Specifying this property forces additional properties that are required to properly template the file. They can be defined per each VM or globally for all VMs (in this case place them in the bootstrap storage definition). The properties are listed below.<br>  - `public_snet_key` : required, name of the key in `var.vnets` map defining a public subnet, required to calculate the Azure router IP for the public subnet.<br>  - `private_snet_key` : required, name of the key in `var.vnets` map defining a private subnet, required to calculate the Azure router IP for the private subnet.<br>  - `intranet_cidr` : optional, CIDR of the private networks required to build a general static route to resources protected by this firewall, when skipped the 1st CIDR from `vnet_name` address space will be used.<br>  - `ai_update_interval` : if Application Insights are used this property can override the default metrics update interval (in minutes).<br><br>- `interfaces` : configuration of all NICs assigned to a VM. A list of maps, each map is a NIC definition. Notice that the order DOES matter. NICs are attached to VMs in Azure in the order they are defined in this list, therefore the management interface has to be defined first. Following properties are available:<br>  - `name`: string that will form the NIC name<br>  - `subnet_key` : (string) a key of a subnet as defined in `var.vnets`<br>  - `create_pip` : (boolean) flag to create Public IP for an interface, defaults to `false`<br>  - `public_ip_name` : (string) when `create_pip` is set to `false` a name of a Public IP resource that should be associated with this Network Interface<br>  - `public_ip_resource_group` : (string) when associating an existing Public IP resource, name of the Resource Group the IP is placed in, defaults to the `var.resource_group_name`<br>  - `load_balancer_key` : (string) key of a Load Balancer defined in the `var.loadbalancers`  variable, defaults to `null`<br>  - `private_ip_address` : (string) a static IP address that should be assigned to an interface, defaults to `null` (in that case DHCP is used)<br><br>Example:<pre>{<br>  "fw01" = {<br>    name = "firewall01"<br>    bootstrap_storage = {<br>      name                   = "storageaccountname"<br>      static_files           = { "files/init-cfg.txt" = "config/init-cfg.txt" }<br>      template_bootstrap_xml = "templates/bootstrap_common.tmpl"<br>      public_snet_key        = "public"<br>      private_snet_key       = "private"<br>    }<br>    avzone   = 1<br>    vnet_key = "trust"<br>    interfaces = [<br>      {<br>        name               = "mgmt"<br>        subnet_key         = "mgmt"<br>        create_pip         = true<br>        private_ip_address = "10.0.0.1"<br>      },<br>      {<br>        name                 = "trust"<br>        subnet_key           = "private"<br>        private_ip_address   = "10.0.1.1"<br>        load_balancer_key    = "private_lb"<br>      },<br>      {<br>        name                 = "untrust"<br>        subnet_key           = "public"<br>        private_ip_address   = "10.0.2.1"<br>        load_balancer_key    = "public_lb"<br>        public_ip_name       = "existing_public_ip"<br>      }<br>    ]<br>  }<br>}</pre> | `any` | n/a | yes |
 | <a name="input_appgws"></a> [appgws](#input\_appgws) | A map defining all Application Gateways in the current deployment.<br><br>For detailed documentation on how to configure this resource, for available properties, especially for the defaults and the `rules` property refer to [module documentation](https://github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules/blob/main/modules/appgw/README.md).<br><br>Following properties are supported:<br>- `name` : name of the Application Gateway.<br>- `vnet_key` : a key of a VNET defined in the `var.vnets` map.<br>- `subnet_key` : a key of a subnet as defined in `var.vnets`. This has to be a subnet dedicated to Application Gateways v2.<br>- `zones` : for zonal deployment this is a list of all zones in a region - this property is used by both: the Application Gateway and the Public IP created in front of the AppGW.<br>- `capacity` : (optional) number of Application Gateway instances, not used when autoscalling is enabled (see `capacity_min`)<br>- `capacity_min` : (optional) when set enables autoscaling and becomes the minimum capacity<br>- `capacity_max` : (optional) maximum capacity for autoscaling<br>- `enable_http2` : enable HTTP2 support on the Application Gateway<br>- `waf_enabled` : (optional) enables WAF Application Gateway, defining WAF rules is not supported, defaults to `false`<br>- `vmseries_public_nic_name` : name of the public VMSeries interface as defined in `interfaces` property.<br>- `managed_identities` : (optional) a list of existing User-Assigned Managed Identities, which Application Gateway uses to retrieve certificates from Key Vault<br>- `ssl_policy_type` : (optional) type of an SSL policy, defaults to `Predefined`<br>- `ssl_policy_name` : (optional) name of an SSL policy, for `ssl_policy_type` set to `Predefined`<br>- `ssl_policy_min_protocol_version` : (optional) minimum version of the TLS protocol for SSL Policy, for `ssl_policy_type` set to `Custom`<br>- `ssl_policy_cipher_suites` : (optional) a list of accepted cipher suites, for `ssl_policy_type` set to `Custom`<br>- `ssl_profiles` : (optional) a map of SSL profiles that can be later on referenced in HTTPS listeners by providing a name of the profile in the `ssl_profile_name` property | `map` | `{}` | no |
 
-## Outputs
+### Outputs
 
 | Name | Description |
 |------|-------------|

--- a/examples/dedicated_vmseries_and_autoscale/README.md
+++ b/examples/dedicated_vmseries_and_autoscale/README.md
@@ -120,21 +120,22 @@ To remove the deployed infrastructure run:
 terraform destroy
 ```
 
+## Reference
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
+### Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2, < 2.0 |
 
-## Providers
+### Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
 
-## Modules
+### Modules
 
 | Name | Source | Version |
 |------|--------|---------|
@@ -145,7 +146,7 @@ terraform destroy
 | <a name="module_appgw"></a> [appgw](#module\_appgw) | ../../modules/appgw | n/a |
 | <a name="module_vmss"></a> [vmss](#module\_vmss) | ../../modules/vmss | n/a |
 
-## Resources
+### Resources
 
 | Name | Type |
 |------|------|
@@ -153,7 +154,7 @@ terraform destroy
 | [random_password.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
-## Inputs
+### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -175,7 +176,7 @@ terraform destroy
 | <a name="input_vmss"></a> [vmss](#input\_vmss) | A map defining all Virtual Machine Scale Sets.<br><br>For detailed documentation on how to configure this resource, for available properties, especially for the defaults refer to [module documentation](../../modules/vmss/README.md)<br><br>Following properties are available:<br>- `name` : (string\|required) name of the Virtual Machine Scale Set.<br>- `vm_size` : size of the VMSeries virtual machines created with this Scale Set, when specified overrides `var.vmseries_vm_size`.<br>- `version` : PanOS version, when specified overrides `var.vmseries_version`.<br>- `vnet_key` : (string\|required) a key of a VNET defined in the `var.vnets` map.<br>- `bootstrap_options` : (string\|`''`) bootstrap options passed to every VM instance upon creation.<br>- `zones` : (list(string)\|`[]`) a list of Availability Zones to use for Zone redundancy<br>- `encryption_at_host_enabled` : (bool\|`null` - Azure defaults) should all of the disks attached to this Virtual Machine be encrypted<br>- `overprovision` : (bool\|`null` - module defaults) when provisioning new VM, multiple will be provisioned but the 1st one to run will be kept<br>- `platform_fault_domain_count` : (number\|`null` - Azure defaults) number of fault domains to use<br>- `proximity_placement_group_id` : (string\|`null`) ID of a proximity placement group the VMSS should be placed in<br>- `scale_in_policy` : (string\|`null` - Azure defaults) policy of removing VMs when scaling in<br>- `scale_in_force_deletion` : (bool\|`null` - module default) forces (`true`) deletion of VMs during scale in<br>- `single_placement_group` : (bool\|`null` - Azure defaults) limit the Scale Set to one Placement Group<br>- `storage_account_type` : (string\|`null` - module defaults) type of managed disk that will be used on all VMs<br>- `disk_encryption_set_id` : (string\|`null`) the ID of the Disk Encryption Set which should be used to encrypt this Data Disk<br>- `accelerated_networking` : (bool\|`null`- module defaults) enable Azure accelerated networking for all dataplane network interfaces<br>- `use_custom_image` : (bool\|`false`) <br>- `custom_image_id` : (string\|reqquired when `use_custom_image` is `true`) absolute ID of your own Custom Image to be used for creating new VM-Series<br>- `application_insights_id` : (string\|`null`) ID of Application Insights instance that should be used to provide metrics for autoscaling<br>- `interfaces` : (list(string)\|`[]`) configuration of all NICs assigned to a VM. A list of maps, each map is a NIC definition. Notice that the order DOES matter. NICs are attached to VMs in Azure in the order they are defined in this list, therefore the management interface has to be defined first. Following properties are available:<br>  - `name` : (string\|required) string that will form the NIC name<br>  - `subnet_key` : (string\|required) a key of a subnet as defined in `var.vnets`<br>  - `create_pip` : (bool\|`false`) flag to create Public IP for an interface, defaults to `false`<br>  - `load_balancer_key` : (string\|`null`) key of a Load Balancer defined in the `var.loadbalancers` variable<br>  - `application_gateway_key` : (string\|`null`) key of an Application Gateway defined in the `var.appgws`<br>  - `pip_domain_name_label` : (string\|`null`) prefix which should be used for the Domain Name Label for each VM instance<br>- `autoscale_config` : (map\|`{}`) map containing basic autoscale configuration<br>  - `count_default` : (number\|`null` - module defaults) default number or instances when autoscalling is not available<br>  - `count_minimum` : (number\|`null` - module defaults) minimum number of instances to reach when scaling in<br>  - `count_maximum` : (number\|`null` - module defaults) maximum number of instances when scaling out<br>  - `notification_emails` : (list(string)\|`null` - module defaults) a list of e-mail addresses to notify about scaling events<br>- `autoscale_metrics` : (map\|`{}`) metrics and thresholds used to trigger scaling events, see module documentation for details<br>- `scaleout_config` : (map\|`{}`) scale out configuration, for details see module documentation<br>  - `statistic` : (string\|`null` - module defaults) aggregation method for statistics coming from different VMs<br>  - `time_aggregation` : (string\|`null` - module defaults) aggregation method applied to statistics in time window<br>  - `window_minutes` : (string\|`null` - module defaults) time windows used to analyze statistics<br>  - `cooldown_minutes` : (string\|`null` - module defaults) time to wait after a scaling event before analyzing the statistics again<br>- `scalein_config` : (map\|`{}`) scale in configuration, same properties supported as for `scaleout_config`<br><br>Example, no auto scaling:<pre>{<br>"vmss" = {<br>  name              = "ngfw-vmss"<br>  vnet_key          = "transit"<br>  bootstrap_options = "type=dhcp"<br><br>  interfaces = [<br>    {<br>      name       = "management"<br>      subnet_key = "management"<br>    },<br>    {<br>      name       = "private"<br>      subnet_key = "private"<br>    },<br>    {<br>      name                    = "public"<br>      subnet_key              = "public"<br>      load_balancer_key       = "public"<br>      application_gateway_key = "public"<br>    }<br>  ]<br>}</pre> | `any` | `{}` | no |
 | <a name="input_appgws"></a> [appgws](#input\_appgws) | A map defining all Application Gateways in the current deployment.<br><br>For detailed documentation on how to configure this resource, for available properties, especially for the defaults and the `rules` property refer to [module documentation](../../modules/appgw/README.md).<br><br>Following properties are supported:<br>- `name` : name of the Application Gateway.<br>- `vnet_key` : a key of a VNET defined in the `var.vnets` map.<br>- `subnet_key` : a key of a subnet as defined in `var.vnets`. This has to be a subnet dedicated to Application Gateways v2.<br>- `vnet_key` : a key of a VNET defined in the `var.vnets` map.<br>- `subnet_key` : a key of a subnet as defined in `var.vnets`. This has to be a subnet dedicated to Application Gateways v2.<br>- `zones` : for zonal deployment this is a list of all zones in a region - this property is used by both: the Application Gateway and the Public IP created in front of the AppGW.<br>- `capacity` : (optional) number of Application Gateway instances, not used when autoscalling is enabled (see `capacity_min`)<br>- `capacity_min` : (optional) when set enables autoscaling and becomes the minimum capacity<br>- `capacity_max` : (optional) maximum capacity for autoscaling<br>- `enable_http2` : enable HTTP2 support on the Application Gateway<br>- `waf_enabled` : (optional) enables WAF Application Gateway, defining WAF rules is not supported, defaults to `false`<br>- `vmseries_public_nic_name` : name of the public VMSeries interface as defined in `interfaces` property.<br>- `managed_identities` : (optional) a list of existing User-Assigned Managed Identities, which Application Gateway uses to retrieve certificates from Key Vault<br>- `ssl_policy_type` : (optional) type of an SSL policy, defaults to `Predefined`<br>- `ssl_policy_name` : (optional) name of an SSL policy, for `ssl_policy_type` set to `Predefined`<br>- `ssl_policy_min_protocol_version` : (optional) minimum version of the TLS protocol for SSL Policy, for `ssl_policy_type` set to `Custom`<br>- `ssl_policy_cipher_suites` : (optional) a list of accepted cipher suites, for `ssl_policy_type` set to `Custom`<br>- `ssl_profiles` : (optional) a map of SSL profiles that can be later on referenced in HTTPS listeners by providing a name of the profile in the `ssl_profile_name` property | `map` | `{}` | no |
 
-## Outputs
+### Outputs
 
 | Name | Description |
 |------|-------------|

--- a/examples/standalone_panorama/README.md
+++ b/examples/standalone_panorama/README.md
@@ -94,28 +94,29 @@ To remove the deployed infrastructure run:
 terraform destroy
 ```
 
+## Reference
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
+### Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2, < 2.0 |
 
-## Providers
+### Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
 
-## Modules
+### Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_vnet"></a> [vnet](#module\_vnet) | ../../modules/vnet | n/a |
 | <a name="module_panorama"></a> [panorama](#module\_panorama) | ../../modules/panorama | n/a |
 
-## Resources
+### Resources
 
 | Name | Type |
 |------|------|
@@ -123,7 +124,7 @@ terraform destroy
 | [random_password.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
-## Inputs
+### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -141,7 +142,7 @@ terraform destroy
 | <a name="input_panorama_size"></a> [panorama\_size](#input\_panorama\_size) | A size of a VM that will run Panorama. It's also possible to specify the the VM size per Panorama, see `var.panoramas` variable. | `string` | `"Standard_D5_v2"` | no |
 | <a name="input_panoramas"></a> [panoramas](#input\_panoramas) | A map containing Panorama definitions.<br><br>All definitions share a VM size, SKU and PanOS version (`panorama_size`, `panorama_sku`, `panorama_version` respectively). Defining more than one Panorama makes sense when creating for example HA pairs. <br><br>Following properties are available:<br><br>- `name` : a name of a Panorama VM<br>- `size` : size of the Panorama virtual machine, when specified overrides `var.panorama_size`.<br>- `version` : PanOS version, when specified overrides `var.panorama_version`.<br>- `vnet_key`: a VNET used to host Panorama VM, this is a key from a VNET definition stored in `vnets` variable<br>- `subnet_key`: a Subnet inside a VNET used to host Panorama VM, this is a key from a Subnet definition stored inside a VNET definition references by the `vnet_key` property<br>- `avzone`: when `enable_zones` is `true` this specifies the zone in which Panorama will be deployed<br>- `avzones`: when `enable_zones` is `true` these are availability zones used by Panorama's public IPs<br>- `custom_image_id`: a custom build of Panorama to use, overrides the stock image version.<br><br>- `interfaces` : configuration of all NICs assigned to a VM. A list of maps, each map is a NIC definition. Notice that the order DOES matter. NICs are attached to VMs in Azure in the order they are defined in this list, therefore the management interface has to be defined first. Following properties are available:<br>  - `name`: string that will form the NIC name<br>  - `subnet_key` : (string) a key of a subnet as defined in `var.vnets`<br>  - `create_pip` : (boolean) flag to create Public IP for an interface, defaults to `false`<br>  - `public_ip_name` : (string) when `create_pip` is set to `false` a name of a Public IP resource that should be associated with this Network Interface<br>  - `public_ip_resource_group` : (string) when associating an existing Public IP resource, name of the Resource Group the IP is placed in, defaults to the `var.resource_group_name`<br>  - `private_ip_address` : (string) a static IP address that should be assigned to an interface, defaults to `null` (in that case DHCP is used)<br><br>- `logging_disks` : a map containing configuration of additional disks that should be attached to a Panorama appliance. Following properties are available:<br>  - `size` : size of a disk, 2TB by default<br>  - `lun` : slot to which the disk should be attached<br>  - `disk_type` : type of a disk, determines throughput, `Standard_LRS` by default.<br><br>Example:<pre>{<br>    "pn-1" = {<br>      name     = "panorama01"<br>      vnet_key = "vnet"<br>      interfaces = [<br>        {<br>          name               = "management"<br>          subnet_key         = "panorama"<br>          private_ip_address = "10.1.0.10"<br>          create_pip         = true<br>        },<br>      ]<br>    }<br>  }</pre> | `any` | `{}` | no |
 
-## Outputs
+### Outputs
 
 | Name | Description |
 |------|-------------|

--- a/examples/standalone_vmseries/README.md
+++ b/examples/standalone_vmseries/README.md
@@ -93,14 +93,15 @@ To remove the deployed infrastructure run:
 terraform destroy
 ```
 
+## Reference
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
+### Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2, < 2.0 |
 
-## Providers
+### Providers
 
 | Name | Version |
 |------|---------|
@@ -108,7 +109,7 @@ terraform destroy
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
 | <a name="provider_local"></a> [local](#provider\_local) | n/a |
 
-## Modules
+### Modules
 
 | Name | Source | Version |
 |------|--------|---------|
@@ -121,7 +122,7 @@ terraform destroy
 | <a name="module_vmseries"></a> [vmseries](#module\_vmseries) | ../../modules/vmseries | n/a |
 | <a name="module_appgw"></a> [appgw](#module\_appgw) | ../../modules/appgw | n/a |
 
-## Resources
+### Resources
 
 | Name | Type |
 |------|------|
@@ -131,7 +132,7 @@ terraform destroy
 | [random_password.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
-## Inputs
+### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -155,7 +156,7 @@ terraform destroy
 | <a name="input_vmseries"></a> [vmseries](#input\_vmseries) | Map of virtual machines to create to run VM-Series - inbound firewalls. Following properties are supported:<br><br>- `name` : name of the VMSeries virtual machine.<br>- `vm_size` : size of the VMSeries virtual machine, when specified overrides `var.vmseries_vm_size`.<br>- `version` : PanOS version, when specified overrides `var.vmseries_version`.<br>- `vnet_key` : a key of a VNET defined in the `var.vnets` map. This value will be used during network interfaces creation.<br>- `add_to_appgw_backend` : bool, `false` by default, set this to `true` to add this backend to an Application Gateway.<br>- `avzone`: the Azure Availability Zone identifier ("1", "2", "3"). Default is "1".<br>- `availability_set_name` : a name of an Availability Set as declared in `availability_set` property. Specify when HA is required but cannot go for zonal deployment.<br><br>- `bootstrap_options` : string, optional bootstrap options to pass to VM-Series instances, semicolon separated values. When defined this precedence over `bootstrap_storage`<br>- `bootstrap_storage` : a map containing definition of the bootstrap package content. When present triggers a creation of a File Share in an existing Storage Account, following properties supported:<br>  - `name` : a name of a key in `var.bootstrap_storage` variable defining a Storage Account<br>  - `static_files` : a map where key is a path to a file, value is the location of the file in the bootstrap package (file share). All files in this map are copied 1:1 to the bootstrap package<br>  - `template_bootstrap_xml` : path to the `bootstrap.xml` template. When defined it will trigger creation of the `bootstrap.xml` file and the file will be uploaded to the storage account. This is a simple `day 0` configuration file that should set up only basic networking. Specifying this property forces additional properties that are required to properly template the file. They can be defined per each VM or globally for all VMs (in this case place them in the bootstrap storage definition). The properties are listed below.<br>  - `public_snet_key` : required, name of the key in `var.vnets` map defining a public subnet, required to calculate the Azure router IP for the public subnet.<br>  - `private_snet_key` : required, name of the key in `var.vnets` map defining a private subnet, required to calculate the Azure router IP for the private subnet.<br>  - `intranet_cidr` : optional, CIDR of the private networks required to build a general static route to resources protected by this firewall, when skipped the 1st CIDR from `vnet_name` address space will be used.<br>  - `ai_update_interval` : if Application Insights are used this property can override the default metrics update interval (in minutes).<br><br>- `interfaces` : configuration of all NICs assigned to a VM. A list of maps, each map is a NIC definition. Notice that the order DOES matter. NICs are attached to VMs in Azure in the order they are defined in this list, therefore the management interface has to be defined first. Following properties are available:<br>  - `name`: string that will form the NIC name<br>  - `subnet_key` : (string) a key of a subnet as defined in `var.vnets`<br>  - `create_pip` : (boolean) flag to create Public IP for an interface, defaults to `false`<br>  - `public_ip_name` : (string) when `create_pip` is set to `false` a name of a Public IP resource that should be associated with this Network Interface<br>  - `public_ip_resource_group` : (string) when associating an existing Public IP resource, name of the Resource Group the IP is placed in, defaults to the `var.resource_group_name`<br>  - `load_balancer_key` : (string) key of a Load Balancer defined in the `var.loadbalancers`  variable, defaults to `null`<br>  - `private_ip_address` : (string) a static IP address that should be assigned to an interface, defaults to `null` (in that case DHCP is used)<br><br>Example:<pre>{<br>  "fw01" = {<br>    name = "firewall01"<br>    bootstrap_storage = {<br>      name                   = "storageaccountname"<br>      static_files           = { "files/init-cfg.txt" = "config/init-cfg.txt" }<br>      template_bootstrap_xml = "templates/bootstrap_common.tmpl"<br>      public_snet_key        = "public"<br>      private_snet_key       = "private"<br>    }<br>    avzone   = 1<br>    vnet_key = "trust"<br>    interfaces = [<br>      {<br>        name               = "mgmt"<br>        subnet_key         = "mgmt"<br>        create_pip         = true<br>        private_ip_address = "10.0.0.1"<br>      },<br>      {<br>        name                 = "trust"<br>        subnet_key           = "private"<br>        private_ip_address   = "10.0.1.1"<br>        load_balancer_key    = "private_lb"<br>      },<br>      {<br>        name                 = "untrust"<br>        subnet_key           = "public"<br>        private_ip_address   = "10.0.2.1"<br>        load_balancer_key    = "public_lb"<br>        public_ip_name       = "existing_public_ip"<br>      }<br>    ]<br>  }<br>}</pre> | `any` | n/a | yes |
 | <a name="input_appgws"></a> [appgws](#input\_appgws) | A map defining all Application Gateways in the current deployment.<br><br>For detailed documentation on how to configure this resource, for available properties, especially for the defaults and the `rules` property refer to [module documentation](https://github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules/blob/main/modules/appgw/README.md).<br><br>Following properties are supported:<br>- `name` : name of the Application Gateway.<br>- `vnet_key` : a key of a VNET defined in the `var.vnets` map.<br>- `subnet_key` : a key of a subnet as defined in `var.vnets`. This has to be a subnet dedicated to Application Gateways v2.<br>- `zones` : for zonal deployment this is a list of all zones in a region - this property is used by both: the Application Gateway and the Public IP created in front of the AppGW.<br>- `capacity` : (optional) number of Application Gateway instances, not used when autoscalling is enabled (see `capacity_min`)<br>- `capacity_min` : (optional) when set enables autoscaling and becomes the minimum capacity<br>- `capacity_max` : (optional) maximum capacity for autoscaling<br>- `enable_http2` : enable HTTP2 support on the Application Gateway<br>- `waf_enabled` : (optional) enables WAF Application Gateway, defining WAF rules is not supported, defaults to `false`<br>- `vmseries_public_nic_name` : name of the public VMSeries interface as defined in `interfaces` property.<br>- `managed_identities` : (optional) a list of existing User-Assigned Managed Identities, which Application Gateway uses to retrieve certificates from Key Vault<br>- `ssl_policy_type` : (optional) type of an SSL policy, defaults to `Predefined`<br>- `ssl_policy_name` : (optional) name of an SSL policy, for `ssl_policy_type` set to `Predefined`<br>- `ssl_policy_min_protocol_version` : (optional) minimum version of the TLS protocol for SSL Policy, for `ssl_policy_type` set to `Custom`<br>- `ssl_policy_cipher_suites` : (optional) a list of accepted cipher suites, for `ssl_policy_type` set to `Custom`<br>- `ssl_profiles` : (optional) a map of SSL profiles that can be later on referenced in HTTPS listeners by providing a name of the profile in the `ssl_profile_name` property | `map` | `{}` | no |
 
-## Outputs
+### Outputs
 
 | Name | Description |
 |------|-------------|

--- a/modules/appgw/README.md
+++ b/modules/appgw/README.md
@@ -453,32 +453,33 @@ rules = {
 }
 ```
 
+## Reference
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
+### Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2, < 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.25 |
 
-## Providers
+### Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.25 |
 
-## Modules
+### Modules
 
 No modules.
 
-## Resources
+### Resources
 
 | Name | Type |
 |------|------|
 | [azurerm_application_gateway.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_gateway) | resource |
 | [azurerm_public_ip.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 
-## Inputs
+### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -503,7 +504,7 @@ No modules.
 | <a name="input_ssl_profiles"></a> [ssl\_profiles](#input\_ssl\_profiles) | A map of SSL profiles that can be later on referenced in HTTPS listeners by providing a name of the profile in the `ssl_profile_name` property. <br><br>The structure of the map is as follows:<pre>{<br>  profile_name = {<br>    ssl_policy_type                 = string<br>    ssl_policy_min_protocol_version = string<br>    ssl_policy_cipher_suites        = list<br>  }<br>}</pre>For possible values check the: `ssl_policy_type`, `ssl_policy_min_protocol_version` and `ssl_policy_cipher_suites` variables as SSL profile is a named SSL policy - same properties apply. The only difference is that you cannot name an SSL policy inside an SSL profile. | `map(any)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Azure tags to apply to the created resources. | `map(string)` | `{}` | no |
 
-## Outputs
+### Outputs
 
 | Name | Description |
 |------|-------------|

--- a/modules/application_insights/README.md
+++ b/modules/application_insights/README.md
@@ -37,32 +37,33 @@ module "ai" {
 }
 ```  
 
+## Reference
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
+### Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2, < 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.25 |
 
-## Providers
+### Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.25 |
 
-## Modules
+### Modules
 
 No modules.
 
-## Resources
+### Resources
 
 | Name | Type |
 |------|------|
 | [azurerm_application_insights.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights) | resource |
 | [azurerm_log_analytics_workspace.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 
-## Inputs
+### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -75,7 +76,7 @@ No modules.
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | A name of an existing Resource Group. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags assigned to all resources created by this module. | `map(string)` | `{}` | no |
 
-## Outputs
+### Outputs
 
 | Name | Description |
 |------|-------------|

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -44,8 +44,9 @@ resource "local_file" "this" {
 }
 ```
 
+## Reference
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
+### Requirements
 
 | Name | Version |
 |------|---------|
@@ -53,17 +54,17 @@ resource "local_file" "this" {
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.25 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
 
-## Providers
+### Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.25 |
 
-## Modules
+### Modules
 
 No modules.
 
-## Resources
+### Resources
 
 | Name | Type |
 |------|------|
@@ -73,7 +74,7 @@ No modules.
 | [azurerm_storage_share_file.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_share_file) | resource |
 | [azurerm_storage_account.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 
-## Inputs
+### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -89,7 +90,7 @@ No modules.
 | <a name="input_storage_share_access_tier"></a> [storage\_share\_access\_tier](#input\_storage\_share\_access\_tier) | Access tier for the File Share. | `string` | `"Cool"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to be associated with the resources created. | `map(string)` | `{}` | no |
 
-## Outputs
+### Outputs
 
 | Name | Description |
 |------|-------------|

--- a/modules/loadbalancer/README.md
+++ b/modules/loadbalancer/README.md
@@ -8,25 +8,26 @@ The module creates a single load balancer and a single backend for it, but it al
 
 For usage see any of the reference architecture examples.
 
+## Reference
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
+### Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2, < 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.25 |
 
-## Providers
+### Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.25 |
 
-## Modules
+### Modules
 
 No modules.
 
-## Resources
+### Resources
 
 | Name | Type |
 |------|------|
@@ -39,7 +40,7 @@ No modules.
 | [azurerm_public_ip.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_public_ip.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip) | data source |
 
-## Inputs
+### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -58,7 +59,7 @@ No modules.
 | <a name="input_tags"></a> [tags](#input\_tags) | Azure tags to apply to the created resources. | `map(string)` | `{}` | no |
 | <a name="input_avzones"></a> [avzones](#input\_avzones) | Controls zones for load balancer's Fronted IP configurations. For:<br><br>* public IPs - these are regions in which the IP resource is available<br>* private IPs - this represents Zones to which Azure will deploy paths leading to this Frontend IP.<br><br>For public IPs, after provider version 3.x (Azure API upgrade) you need to specify all zones available in a region (typically 3), ie: for zone-redundant with 3 availability zone in current region value will be:<pre>["1","2","3"]</pre> | `list(string)` | `[]` | no |
 
-## Outputs
+### Outputs
 
 | Name | Description |
 |------|-------------|

--- a/modules/natgw/README.md
+++ b/modules/natgw/README.md
@@ -23,25 +23,26 @@ module "natgw" {
 
 This will create a NAT Gateway in with a single Public IP in a zone chosen by Azure.
 
+## Reference
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
+### Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2, < 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.25 |
 
-## Providers
+### Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.25 |
 
-## Modules
+### Modules
 
 No modules.
 
-## Resources
+### Resources
 
 | Name | Type |
 |------|------|
@@ -55,7 +56,7 @@ No modules.
 | [azurerm_public_ip.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip) | data source |
 | [azurerm_public_ip_prefix.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip_prefix) | data source |
 
-## Inputs
+### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -75,7 +76,7 @@ No modules.
 | <a name="input_existing_pip_prefix_name"></a> [existing\_pip\_prefix\_name](#input\_existing\_pip\_prefix\_name) | Name of an existing Public IP Prefix resource to associate with the NAT Gateway. Only for newly created resources. | `string` | `null` | no |
 | <a name="input_existing_pip_prefix_resource_group_name"></a> [existing\_pip\_prefix\_resource\_group\_name](#input\_existing\_pip\_prefix\_resource\_group\_name) | Name of a resource group hosting the Public IP Prefix resource specified in `existing_pip_name`. When omitted Resource Group specified in `resource_group_name` will be used. | `string` | `null` | no |
 
-## Outputs
+### Outputs
 
 | Name | Description |
 |------|-------------|

--- a/modules/panorama/README.md
+++ b/modules/panorama/README.md
@@ -33,8 +33,9 @@ module "panorama" {
 }
 ```
 
+## Reference
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
+### Requirements
 
 | Name | Version |
 |------|---------|
@@ -42,17 +43,17 @@ module "panorama" {
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.25 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
 
-## Providers
+### Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.25 |
 
-## Modules
+### Modules
 
 No modules.
 
-## Resources
+### Resources
 
 | Name | Type |
 |------|------|
@@ -63,7 +64,7 @@ No modules.
 | [azurerm_virtual_machine_data_disk_attachment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_data_disk_attachment) | resource |
 | [azurerm_public_ip.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip) | data source |
 
-## Inputs
+### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -90,7 +91,7 @@ No modules.
 | <a name="input_boot_diagnostic_storage_uri"></a> [boot\_diagnostic\_storage\_uri](#input\_boot\_diagnostic\_storage\_uri) | Existing diagnostic storage uri | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to be associated with the resources created. | `map(any)` | `{}` | no |
 
-## Outputs
+### Outputs
 
 | Name | Description |
 |------|-------------|

--- a/modules/virtual_machine/.README.md
+++ b/modules/virtual_machine/.README.md
@@ -26,6 +26,7 @@ module "vm" {
 }
 ```
 
+## Reference
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -31,25 +31,26 @@ If your Region doesn't, use an alternative mechanism of Availability Set, which 
    avzone   = null
 ```
 
+## Reference
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
+### Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2, < 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.25 |
 
-## Providers
+### Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.25 |
 
-## Modules
+### Modules
 
 No modules.
 
-## Resources
+### Resources
 
 | Name | Type |
 |------|------|
@@ -59,7 +60,7 @@ No modules.
 | [azurerm_virtual_machine.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine) | resource |
 | [azurerm_public_ip.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip) | data source |
 
-## Inputs
+### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -90,7 +91,7 @@ No modules.
 | <a name="input_bootstrap_options"></a> [bootstrap\_options](#input\_bootstrap\_options) | Bootstrap options to pass to VM-Series instance.<br><br>Proper syntax is a string of semicolon separated properties.<br>Example:<br>  bootstrap\_options = "type=dhcp-client;panorama-server=1.2.3.4"<br><br>A list of available properties: storage-account, access-key, file-share, share-directory, type, ip-address, default-gateway, netmask, ipv6-address, ipv6-default-gateway, hostname, panorama-server, panorama-server-2, tplname, dgname, dns-primary, dns-secondary, vm-auth-key, op-command-modes, op-cmd-dpdk-pkt-io, plugin-op-commands, dhcp-send-hostname, dhcp-send-client-id, dhcp-accept-server-hostname, dhcp-accept-server-domain, auth-key, vm-series-auto-registration-pin-value, vm-series-auto-registration-pin-id.<br><br>For more details on bootstrapping see documentation: https://docs.paloaltonetworks.com/vm-series/10-2/vm-series-deployment/bootstrap-the-vm-series-firewall/create-the-init-cfgtxt-file/init-cfgtxt-file-components | `string` | `""` | no |
 | <a name="input_diagnostics_storage_uri"></a> [diagnostics\_storage\_uri](#input\_diagnostics\_storage\_uri) | The storage account's blob endpoint to hold diagnostic files. | `string` | `null` | no |
 
-## Outputs
+### Outputs
 
 | Name | Description |
 |------|-------------|

--- a/modules/vmss/README.md
+++ b/modules/vmss/README.md
@@ -36,32 +36,33 @@ module "vmss" {
 }
 ```
 
+## Reference
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
+### Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2, < 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.25 |
 
-## Providers
+### Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.25 |
 
-## Modules
+### Modules
 
 No modules.
 
-## Resources
+### Resources
 
 | Name | Type |
 |------|------|
 | [azurerm_linux_virtual_machine_scale_set.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine_scale_set) | resource |
 | [azurerm_monitor_autoscale_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_autoscale_setting) | resource |
 
-## Inputs
+### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -111,7 +112,7 @@ No modules.
 | <a name="input_bootstrap_options"></a> [bootstrap\_options](#input\_bootstrap\_options) | Bootstrap options to pass to VM-Series instance.<br><br>Proper syntax is a string of semicolon separated properties.<br>Example:<br>  bootstrap\_options = "type=dhcp-client;panorama-server=1.2.3.4"<br><br>For more details on bootstrapping see documentation: https://docs.paloaltonetworks.com/vm-series/10-2/vm-series-deployment/bootstrap-the-vm-series-firewall/create-the-init-cfgtxt-file/init-cfgtxt-file-components | `string` | `""` | no |
 | <a name="input_diagnostics_storage_uri"></a> [diagnostics\_storage\_uri](#input\_diagnostics\_storage\_uri) | The storage account's blob endpoint to hold diagnostic files. | `string` | `null` | no |
 
-## Outputs
+### Outputs
 
 | Name | Description |
 |------|-------------|

--- a/modules/vnet/README.md
+++ b/modules/vnet/README.md
@@ -6,25 +6,26 @@ A terraform module for deploying a Virtual Network and its components required f
 
 For usage refer to any example module.
 
+## Reference
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
+### Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2, < 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.25 |
 
-## Providers
+### Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.25 |
 
-## Modules
+### Modules
 
 No modules.
 
-## Resources
+### Resources
 
 | Name | Type |
 |------|------|
@@ -39,7 +40,7 @@ No modules.
 | [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
 
-## Inputs
+### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -55,7 +56,7 @@ No modules.
 | <a name="input_route_tables"></a> [route\_tables](#input\_route\_tables) | Map of objects describing a Route Table.<br>List of available attributes of each Route Table entry:<br>- `name`: Name of a Route Table.<br>- `location` : (Optional) Specifies the Azure location where to deploy the resource.<br>- `routes` : (Optional) Map of routes within the Route Table.<br>  List of available attributes of each route entry:<br>  - `address_prefix` : The destination CIDR to which the route applies, such as `10.1.0.0/16`.<br>  - `next_hop_type` : The type of Azure hop the packet should be sent to.<br>    Possible values are: `VirtualNetworkGateway`, `VnetLocal`, `Internet`, `VirtualAppliance` and `None`.<br>  - `next_hop_in_ip_address` : Contains the IP address packets should be forwarded to. <br>    Next hop values are only allowed in routes where the next hop type is `VirtualAppliance`.<br><br>Example:<pre>{<br>  "rt_1" = {<br>    name = "route_table_1"<br>    routes = {<br>      "route_1" = {<br>        address_prefix = "10.1.0.0/16"<br>        next_hop_type  = "vnetlocal"<br>      },<br>      "route_2" = {<br>        address_prefix = "10.2.0.0/16"<br>        next_hop_type  = "vnetlocal"<br>      },<br>    }<br>  },<br>  "rt_2" = {<br>    name = "route_table_2"<br>    routes = {<br>      "route_3" = {<br>        address_prefix         = "0.0.0.0/0"<br>        next_hop_type          = "VirtualAppliance"<br>        next_hop_in_ip_address = "10.112.0.100"<br>      }<br>    },<br>  },<br>}</pre> | `map` | `{}` | no |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | Map of subnet objects to create within a virtual network. If `create_subnets` is set to `false` this is just a mapping between the existing subnets and UDRs and NSGs that should be assigned to them.<br><br>List of available attributes of each subnet entry:<br>- `name` - Name of a subnet.<br>- `address_prefixes` : The address prefix to use for the subnet. Only required when a subnet will be created.<br>- `network_security_group` : The Network Security Group identifier to associate with the subnet.<br>- `route_table_id` : The Route Table identifier to associate with the subnet.<br>- `enable_storage_service_endpoint` : Flag that enables `Microsoft.Storage` service endpoint on a subnet. This is a suggested setting for the management interface when full bootstrapping using an Azure Storage Account is used. Defaults to `false`.<br>Example:<pre>{<br>  "management" = {<br>    name                            = "management-snet"<br>    address_prefixes                = ["10.100.0.0/24"]<br>    network_security_group          = "network_security_group_1"<br>    route_table                     = "route_table_1"<br>    enable_storage_service_endpoint = true<br>  },<br>  "private" = {<br>    name                   = "private-snet"<br>    address_prefixes       = ["10.100.1.0/24"]<br>    network_security_group = "network_security_group_2"<br>    route_table            = "route_table_2"<br>  },<br>  "public" = {<br>    name                   = "public-snet"<br>    address_prefixes       = ["10.100.2.0/24"]<br>    network_security_group = "network_security_group_3"<br>    route_table            = "route_table_3"<br>  },<br>}</pre> | `any` | n/a | yes |
 
-## Outputs
+### Outputs
 
 | Name | Description |
 |------|-------------|


### PR DESCRIPTION
## Description
- Updating pre-commit to increase markdown header indentation from default 2 to 3
- Updated all READMEs via a new pre-commit execution to make the indentation changes
- Updated all REAMDEs to be ready for SWFW Hub with a new level 2 header for `Reference`

## Motivation and Context
All changes in this PR support the go-live for the SWFW Hub

## How Has This Been Tested?
Tested locally

## Types of changes
- Docs
- Pre-commit

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.