### PR TITLE
ci: initroduce chatops

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -1,0 +1,57 @@
+name: ChatOPS dispatcher
+run-name: "ChatOPS bot for PR - (#${{ github.event.issue.number }}) ${{ github.event.issue.title }}"
+
+permissions:
+  contents: read
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  dispatch:
+    name: Dispatch a test job
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: get PR head branch
+        uses: actions/github-script@v6
+        id: pr
+        with:
+          result-encoding: string
+          script: |
+            let pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            })
+            console.log(pr.data.head.ref)
+            return pr.data.head.ref
+            
+      - name: "dispatch test command on branch: ${{ steps.pr.outputs.result }}"
+        id: scd
+        uses: peter-evans/slash-command-dispatch@v3
+        with:
+          token: ${{ secrets.CHATOPS }}
+          issue-type: pull-request
+          dispatch-type: workflow
+          permission: write
+          commands: |
+            test
+          static-args: |
+            comment-id=${{ github.event.comment.id }}
+            pr-id=${{ github.event.issue.number }}
+            pr-title=${{ github.event.issue.title }}
+            branch=${{ steps.pr.outputs.result }}
+
+      - name: Edit comment with error message
+        if: steps.scd.outputs.error-message
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          body: |
+            > ${{ steps.scd.outputs.error-message }}
+          reactions: '-1'
+          reactions-edit-mode: replace

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ secrets.CHATOPS }}
           issue-type: pull-request
           dispatch-type: workflow
-          permission: write
+          permission: maintain
           commands: |
             test
           static-args: |

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -1,0 +1,94 @@
+name: ChatOPS tester
+run-name: "On demand tests for PR - (#${{ github.event.inputs.pr-id }}) ${{ github.event.inputs.pr-title }}"
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      paths:
+        description: Space delimited list of module paths to test
+        type: string
+        required: true
+      tf_version:
+        description: Terraform versions to use for tests, comma-separated list
+        type: string
+      pr-id:
+        description: ID of the PR that triggered this workflow
+        required: true
+      pr-title: 
+        description: Title of the PR that triggered this workflow
+        type: string
+        required: true
+      comment-id:
+        description: 'The comment-id of the slash command'
+        required: true
+      branch:
+        description: Branch on which the tests should run
+        type: string
+        default: main
+      do_apply:
+        description: When set to true runs also apply
+        type: string
+        default: "false"
+
+jobs:
+  init:
+    name: Add a comment to originating PR with job ID
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    outputs:
+      paths: ${{ steps.paths_reformat.outputs.paths }}
+    steps:
+      - name: add comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          comment-id: ${{ inputs.comment-id }}
+          issue-number: ${{ inputs.pr-id }}
+          body: |
+            > Testing job ID: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+      - name: reformat paths input property
+        id: paths_reformat
+        env:
+          IN_PATHS: ${{ inputs.paths }}
+        run: |
+          set -x
+          echo "paths=$(echo $IN_PATHS | tr " " "," )" >> $GITHUB_OUTPUT
+
+  plan_apply:
+    name: Run on-demand tests
+    needs: init
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_tf_plan_apply.yml@v1
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      cloud: azure
+      tf_version: ${{ inputs.tf_version }}
+      paths: ${{ needs.init.outputs.paths }}
+      branch: ${{ inputs.branch }}
+      do_apply: ${{ inputs.do_apply == 'true' && true || false }}
+    secrets: inherit
+  
+  finish_comment_pr:
+    name: Add a comment to originating PR
+    needs: plan_apply
+    if: always()
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: add comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          comment-id: ${{ inputs.comment-id }}
+          issue-number: ${{ inputs.pr-id }}
+          body: |
+            > Job result: ${{ needs.plan_apply.result == 'success' && 'SUCCESS' || 'FAILURE' }}
+          reactions: ${{ needs.plan_apply.result == 'success' && '+1' || '-1' }}
+          reactions-edit-mode: replace


### PR DESCRIPTION
# ChatOPS - on demand testing

## Why

Sometimes there is a need to test something more/else that what is available in `PR CI`. For example: `PR CI` does not deploy any infrastructure, for complex changes it might be a good idea to deploy the infra before the `Release CI` (which runs deployment on all examples before releasing a version).

To make this possible a chatops-like CI is introduced. It reacts on `/test` command in a PR's comment and triggers a [`_tf_plan_apply`](https://github.com/PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/blob/main/.github/workflows/_tf_plan_apply.yml) workflow with similar parameters to those passed by `Release CI`. This basically means a possibility to deploy infrastructure during a PR.

## How

To run the deployment add a comment to a PR with a command, one line. The command for the moment is `/test`.

After the command parameters can be placed, space delimited list. For the moment there are three parameters: 

- `paths` - (required) a space delimited list of paths that should be tested. This can be a single path as well
- `tf_version` - (optional) a space delimited list of `Terraform versions`. When omited the latest version will be used.
- `do_apply` - (optional) `true` or `false` (default) - triggers actual deployment, or just planning

  **NOTE** \
  The TF versions specified have to be supported by the modules.

## Examples

- run tests on a single path, TF versions 1.2 and 1.4:

  ```bash
  /test paths="examples/standalone_vmseries" tf_version="1.2 1.4"
  ```

- run tests on two paths, latest TF version, with deployment:

  ```bash
  /test paths="examples/standalone_vmseries examples/standalone_panorama" do_apply=true
  ```

## The Flow

1. A command is issued as a comment to a PR
2. The [`ChatOPS dispatcher`](https://github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules/blob/chatops/.github/workflows/chatops.yml) workflow kicks in
   1. it analyses the comment
   2. tries to run the actual test CI
   3. if it succeeds, the comment is updated with 🚀  and 👀 reactions - this is an indicator that the test workflow is running 
   4. if it fails, a comment is updated with a failure reason and the reaction is changed to 👎🏻 
       ![image](https://github.com/PaloAltoNetworks/vm-series-gh-actions/assets/42772730/864b35e4-9541-4b6e-b46d-519460ec69d3)

3. The [`ChatOPS tester`](https://github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules/blob/chatops/.github/workflows/test-command.yml) workflow is dispatched
   1. it updates the comment with a link to the test job
   2. it triggers the [`_tf_plan_apply`](https://github.com/PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/blob/main/.github/workflows/_tf_plan_apply.yml) reusable workflow passing all required information.
   3. when the reusable workflow is finished the comment is updated with the test results. For `success` the reaction is changed to 👍🏻  and 👎🏻 otherwise.
     ![image](https://github.com/PaloAltoNetworks/vm-series-gh-actions/assets/42772730/ef647fc3-fa51-4d2f-a820-e3de4e92ed85)

## Testing

To test it one can use a [copy of the Azure repo](https://github.com/PaloAltoNetworks/vm-series-gh-actions/pull/71) (internal), as the chatops workflows need to be on the `main` branch to trigger.