### PR TITLE
ci: bump workflows to newer release

### DIFF
--- a/.github/workflows/apply-command.yml
+++ b/.github/workflows/apply-command.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.1.1
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.1.2
     secrets: inherit
     with:
       paths: ${{ inputs.paths }}

--- a/.github/workflows/idempotence-command.yml
+++ b/.github/workflows/idempotence-command.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.1.1
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.1.2
     secrets: inherit
     with:
       paths: ${{ inputs.paths }}

--- a/.github/workflows/plan-command.yml
+++ b/.github/workflows/plan-command.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.1.1
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.1.2
     secrets: inherit
     with:
       paths: ${{ inputs.paths }}

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   pr_ci_wrkflw:
     name: Run CI
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/pr_ci.yml@v2.1.1
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/pr_ci.yml@v2.1.2
     secrets: inherit
     if: github.actor != 'dependabot[bot]'
     with:

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -13,13 +13,13 @@ on:
 jobs:
   update:
     name: "Update Pre-Commit dependencies"
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_pre-commit-update.yml@v2.1.1
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_pre-commit-update.yml@v2.1.2
 
   pre-commit:
     name: Run Pre-Commit with the udpated config
     needs: [update]
     if: needs.update.outputs.pr_operation == 'created' || needs.update.outputs.pr_operation == 'updated'
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_pre_commit.yml@v2.1.1
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_pre_commit.yml@v2.1.2
     with:
       pre-commit-hooks: terraform_fmt terraform_docs terraform_tflint checkov
       checkout-branch: pre-commit-dependencies-update
@@ -28,7 +28,7 @@ jobs:
     name: Give comment on the PR if pre-commit failed
     needs: [pre-commit, update]
     if: always() && (needs.pre-commit.result == 'failure' || needs.pre-commit.result == 'success')
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_comment_pr.yml@v2.1.1
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_comment_pr.yml@v2.1.2
     with:
       pr_number: ${{ needs.update.outputs.pr_number }}
       job_result: ${{ needs.pre-commit.result }}

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -17,7 +17,7 @@ concurrency: release
 jobs:
   release_wrkflw:
     name: Do release
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/release_ci.yml@v2.1.1
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/release_ci.yml@v2.1.2
     secrets: inherit
     with:
       cloud: azure

--- a/.github/workflows/sca-command.yml
+++ b/.github/workflows/sca-command.yml
@@ -53,7 +53,7 @@ jobs:
     needs: init
     permissions:
       contents: read
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_pre_commit.yml@v2.1.1
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_pre_commit.yml@v2.1.2
     secrets: inherit
     with:
       pre-commit-hooks: terraform_fmt terraform_docs terraform_tflint checkov

--- a/.github/workflows/validate-command.yml
+++ b/.github/workflows/validate-command.yml
@@ -41,7 +41,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.1.1
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.1.2
     secrets: inherit
     with:
       paths: ${{ inputs.paths }}


### PR DESCRIPTION
## Description

Bump reusable workflows to newer release

## Motivation and Context

[This patch release](https://github.com/PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/releases/tag/v2.1.2) fixes release CI workflow.

## How Has This Been Tested?

Azure repo copy

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
