### PR TITLE
ci: Use a GitHub App for chatops token

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -36,7 +36,7 @@ jobs:
       
       - name: Generate GitHub token
         id: generate-token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@v2
         with:
           app_id: ${{ secrets.CHATOPS_APP_ID }}
           private_key: ${{ secrets.CHATOPS_APP_PRIVATE_KEY }}

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -40,7 +40,8 @@ jobs:
         with:
           app_id: ${{ secrets.CHATOPS_APP_ID }}
           private_key: ${{ secrets.CHATOPS_APP_PRIVATE_KEY }}
-          installation_id: ${{ secrets.CHATOPS_APP_INSTALLATION_ID }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ secrets.CHATOPS_APP_INSTALLATION_ID }}          
 
       - name: "dispatch test command on branch: ${{ steps.pr.outputs.result }}"
         id: scd

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -33,12 +33,20 @@ jobs:
             })
             console.log(pr.data.head.ref)
             return pr.data.head.ref
-            
+      
+      - name: Generate GitHub token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.CHATOPS_APP_ID }}
+          private_key: ${{ secrets.CHATOPS_APP_PRIVATE_KEY }}
+          installation_id: ${{ secrets.CHATOPS_APP_INSTALLATION_ID }}
+
       - name: "dispatch test command on branch: ${{ steps.pr.outputs.result }}"
         id: scd
         uses: peter-evans/slash-command-dispatch@v3
         with:
-          token: ${{ secrets.CHATOPS }}
+          token: ${{ steps.generate-token.outputs.token }}
           issue-type: pull-request
           dispatch-type: workflow
           permission: maintain


### PR DESCRIPTION
## Description

A personal access token is not suitable to be used with the peter-evans/slash-command-dispatch@v3 action.

This will introduce a step to generate a token via a GitHub App in place of a PAT.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
