### PR TITLE
ci: move to gh tokens in chatops

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      actions: write
     steps:
       - name: get PR head branch
         uses: actions/github-script@v6
@@ -34,20 +35,11 @@ jobs:
             console.log(pr.data.head.ref)
             return pr.data.head.ref
       
-      - name: Generate GitHub token
-        id: generate-token
-        uses: tibdex/github-app-token@v2
-        with:
-          app_id: ${{ secrets.CHATOPS_APP_ID }}
-          private_key: ${{ secrets.CHATOPS_APP_PRIVATE_KEY }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ secrets.CHATOPS_APP_INSTALLATION_ID }}          
-
       - name: "dispatch test command on branch: ${{ steps.pr.outputs.result }}"
         id: scd
         uses: peter-evans/slash-command-dispatch@v3
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           issue-type: pull-request
           dispatch-type: workflow
           permission: maintain


### PR DESCRIPTION
## Description

Get away from using PAT or GH apps for chatops workflows.

## Motivation and Context

Less maintenance, more security. Available since [this post](https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/) was published

## How Has This Been Tested?

azure repo copy

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->


- New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
