### PR TITLE
ci: Skip ChatOps steps for comments in issues

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   dispatch:
     name: Dispatch a test job
+    if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Description

PR delivers fix for ChatOps - execute ChatOps logic (token, dispatch etc.) only if comment is from pull request and skip comments from issues

## Motivation and Context

Currently ChatOps action is failing for every comment in issues.

## How Has This Been Tested?

Code was tested on internal clone of the repository.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
