### PR TITLE
docs(modules/gwlb): update README for SWFW Hub

### DIFF
--- a/modules/gwlb/README.md
+++ b/modules/gwlb/README.md
@@ -1,3 +1,11 @@
+# Gateway Load Balancer Module for Azure
+
+A Terraform module for deploying a Gateway Load Balancer for VM-Series firewalls.
+
+## Usage
+
+For usage see any of the reference architecture examples.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ### Requirements
 


### PR DESCRIPTION
## Description

GWLB module doesn't have the title in README causing Hub sync orchestration action to fail.
Adding a short description to make the sync work.

```
DEBUG:root:Processing file: terraform-azurerm-vmseries-modules/modules/vmseries/README.md
DEBUG:root:Processing file: terraform-azurerm-vmseries-modules/modules/gwlb/README.md
Traceback (most recent call last):
  File "/home/runner/work/automation-metadata-collector/automation-metadata-collector/./scripts/process_modules_readmes.py", line 513, in <module>
    main(args.modules_directory, args.dest_directory, args.type)
  File "/home/runner/work/automation-metadata-collector/automation-metadata-collector/./scripts/process_modules_readmes.py", line 474, in main
    tf_modules = get_module_readme_files(Path(modules_directory))
  File "/home/runner/work/automation-metadata-collector/automation-metadata-collector/./scripts/process_modules_readmes.py", line 192, in get_module_readme_files
    tf_module = read_and_parse_readme_file(readme)
  File "/home/runner/work/automation-metadata-collector/automation-metadata-collector/./scripts/process_modules_readmes.py", line 149, in read_and_parse_readme_file
    title = get_meta(
  File "/home/runner/work/automation-metadata-collector/automation-metadata-collector/./scripts/process_modules_readmes.py", line 126, in get_meta
    return default()
  File "/home/runner/work/automation-metadata-collector/automation-metadata-collector/./scripts/process_modules_readmes.py", line 150, in <lambda>
    frontmatter, "title", lambda: re.search(r"^# (.*)", readme_contents).group(1)
AttributeError: 'NoneType' object has no attribute 'group'
Error: Process completed with exit code 1.
```

## How Has This Been Tested?

Tested on a separate branch with Hub orchestration action to create a PR.
