### PR TITLE
ci: increase the default apply timeout

### DIFF
--- a/.github/workflows/apply-command.yml
+++ b/.github/workflows/apply-command.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.3
     secrets: inherit
     with:
       cloud: azure

--- a/.github/workflows/apply-command.yml
+++ b/.github/workflows/apply-command.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@chatops-timeout
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.2
     secrets: inherit
     with:
       cloud: azure

--- a/.github/workflows/apply-command.yml
+++ b/.github/workflows/apply-command.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@chatops-timeout
     secrets: inherit
     with:
       cloud: azure
@@ -50,3 +50,4 @@ jobs:
       comment-id: ${{ inputs.comment-id }}
       branch: ${{ inputs.branch }}
       terratest_action: Apply
+      apply_timeout: 60

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -42,7 +42,7 @@ jobs:
           app_id: ${{ secrets.CHATOPS_APP_ID }}
           private_key: ${{ secrets.CHATOPS_APP_PRIVATE_KEY }}
           installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ secrets.CHATOPS_APP_INSTALLATION_ID }}          
+          installation_retrieval_payload: ${{ secrets.CHATOPS_APP_INSTALLATION_ID }}
 
       - name: "dispatch test command on branch: ${{ steps.pr.outputs.result }}"
         id: scd

--- a/.github/workflows/idempotence-command.yml
+++ b/.github/workflows/idempotence-command.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.3
     secrets: inherit
     with:
       cloud: azure

--- a/.github/workflows/idempotence-command.yml
+++ b/.github/workflows/idempotence-command.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@chatops-timeout
     secrets: inherit
     with:
       cloud: azure
@@ -50,3 +50,4 @@ jobs:
       comment-id: ${{ inputs.comment-id }}
       branch: ${{ inputs.branch }}
       terratest_action: Idempotence
+      apply_timeout: 60

--- a/.github/workflows/idempotence-command.yml
+++ b/.github/workflows/idempotence-command.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@chatops-timeout
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.2
     secrets: inherit
     with:
       cloud: azure

--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -22,4 +22,4 @@ on:
 jobs:
   lint_pr_title:
     name: Lint PR
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/lint_pr_title.yml@v2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/lint_pr_title.yml@v2.3

--- a/.github/workflows/plan-command.yml
+++ b/.github/workflows/plan-command.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.3
     secrets: inherit
     with:
       cloud: azure

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -31,3 +31,4 @@ jobs:
       validate_max_parallel: 20
       test_max_parallel: 10
       terratest_action: Plan # keep in mind that this has to start with capital letter
+      apply_timeout: 60

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   pr_ci_wrkflw:
     name: Run CI
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/pr_ci.yml@v2.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/pr_ci.yml@v2.3
     secrets: inherit
     if: github.actor != 'dependabot[bot]'
     with:

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -13,13 +13,13 @@ on:
 jobs:
   update:
     name: "Update Pre-Commit dependencies"
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_pre-commit-update.yml@v2.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_pre-commit-update.yml@v2.3
 
   pre-commit:
     name: Run Pre-Commit with the udpated config
     needs: [update]
     if: needs.update.outputs.pr_operation == 'created' || needs.update.outputs.pr_operation == 'updated'
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_pre_commit.yml@v2.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_pre_commit.yml@v2.3
     with:
       pre-commit-hooks: terraform_fmt terraform_docs terraform_tflint checkov
       checkout-branch: pre-commit-dependencies-update
@@ -28,7 +28,7 @@ jobs:
     name: Give comment on the PR if pre-commit failed
     needs: [pre-commit, update]
     if: always() && (needs.pre-commit.result == 'failure' || needs.pre-commit.result == 'success')
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_comment_pr.yml@v2.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_comment_pr.yml@v2.3
     with:
       pr_number: ${{ needs.update.outputs.pr_number }}
       job_result: ${{ needs.pre-commit.result }}

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -17,7 +17,7 @@ concurrency: release
 jobs:
   release_wrkflw:
     name: Do release
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/release_ci.yml@v2.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/release_ci.yml@v2.3
     secrets: inherit
     with:
       cloud: azure

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -24,3 +24,4 @@ jobs:
       validate_max_parallel: 20
       test_max_parallel: 5
       terratest_action: Idempotence # keep in mind that this has to start with capital letter
+      apply_timeout: 60

--- a/.github/workflows/sca-command.yml
+++ b/.github/workflows/sca-command.yml
@@ -53,7 +53,7 @@ jobs:
     needs: init
     permissions:
       contents: read
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_pre_commit.yml@v2.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_pre_commit.yml@v2.3
     secrets: inherit
     with:
       pre-commit-hooks: terraform_fmt terraform_docs terraform_tflint checkov

--- a/.github/workflows/validate-command.yml
+++ b/.github/workflows/validate-command.yml
@@ -41,7 +41,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.3
     secrets: inherit
     with:
       cloud: azure


### PR DESCRIPTION
## Description

Increase `apply_timeout` for infrastructure building workflows.

## Motivation and Context

Since our code can sometimes be quite complex, default 30 minutes might not be enough to perform apply or idempotence tests. This gives an option to override this property from the calling workflow level.

Additionally, chatops command had no possibility to override this parameter. This change adds that possibility. 

> [!Important]
> DO NOT MERGE BEFORE -> https://github.com/PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/pull/72

## How Has This Been Tested?

tested on Azure repo copy

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- CI

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
