### PR TITLE
chore(example/gwlb): change region to europe

### DIFF
--- a/examples/gwlb_with_vmseries/example.tfvars
+++ b/examples/gwlb_with_vmseries/example.tfvars
@@ -1,6 +1,6 @@
 # Common
 name_prefix         = "example-"
-location            = "East US"
+location            = "North Europe"
 resource_group_name = "vmseries-gwlb"
 tags = {
   "CreatedBy"   = "Palo Alto Networks"


### PR DESCRIPTION
## Description

Change region to North Europe for GWLB example.

## Motivation and Context

For whatever reason terraform has problems with refreshing state when a storage account is created in East US region. THis causes the Release CI to constantly fail. The problem is repeatable but affects only East US. Hence changing the example region to North Europe.

## How Has This Been Tested?

locally and chatops

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
