### PR TITLE
fix(examples/standalone_panorama): fix to be deployable with the defaults

### DIFF
--- a/examples/standalone_panorama/main.tf
+++ b/examples/standalone_panorama/main.tf
@@ -60,17 +60,16 @@ module "panorama" {
 
   for_each = var.panoramas
 
-  name                        = "${var.name_prefix}${each.value.name}"
-  resource_group_name         = local.resource_group.name
-  location                    = var.location
-  avzone                      = try(each.value.avzone, null)
-  avzones                     = try(each.value.avzones, ["1", "2", "3"])
-  enable_zones                = var.enable_zones
-  custom_image_id             = try(each.value.custom_image_id, null)
-  panorama_sku                = var.panorama_sku
-  panorama_size               = try(each.value.size, var.panorama_size)
-  panorama_version            = try(each.value.version, var.panorama_version)
-  boot_diagnostic_storage_uri = ""
+  name                = "${var.name_prefix}${each.value.name}"
+  resource_group_name = local.resource_group.name
+  location            = var.location
+  avzone              = try(each.value.avzone, null)
+  avzones             = try(each.value.avzones, ["1", "2", "3"])
+  enable_zones        = var.enable_zones
+  custom_image_id     = try(each.value.custom_image_id, null)
+  panorama_sku        = var.panorama_sku
+  panorama_size       = try(each.value.size, var.panorama_size)
+  panorama_version    = try(each.value.version, var.panorama_version)
 
   interfaces = [for v in each.value.interfaces : {
     name                     = "${var.name_prefix}${each.value.name}-${v.name}"

--- a/modules/panorama/main.tf
+++ b/modules/panorama/main.tf
@@ -74,9 +74,12 @@ resource "azurerm_virtual_machine" "panorama" {
     admin_password = var.password
   }
 
-  boot_diagnostics {
-    enabled     = var.boot_diagnostic_storage_uri != null ? true : false
-    storage_uri = var.boot_diagnostic_storage_uri
+  dynamic "boot_diagnostics" {
+    for_each = var.boot_diagnostic_storage_uri != null ? [1] : []
+    content {
+      enabled     = true
+      storage_uri = var.boot_diagnostic_storage_uri
+    }
   }
 
   os_profile_linux_config {


### PR DESCRIPTION
## Description

A fix for how we are handling the bootstrap storage in the panorama module. 

## Motivation and Context

As pointed out by @PenDrag0n7 (#364), the module is not usable with the default values. The problematic part was the condition around bootstrap storage uri parameter that did not allow a default null.

## How Has This Been Tested?

A workaround found in the Panorama example was removed and example was deployed.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
